### PR TITLE
Add a network tab

### DIFF
--- a/content/docs/established-information/meta.json
+++ b/content/docs/established-information/meta.json
@@ -6,7 +6,8 @@
         "---Specific Categories---",
         "server",
         "client",
-        "gameplay"
+        "gameplay",
+        "network"
     ],
     "icon": "Construction"
 }

--- a/content/docs/established-information/network/endpoints/meta.json
+++ b/content/docs/established-information/network/endpoints/meta.json
@@ -1,0 +1,5 @@
+{
+    "title": "Endpoints",
+    "index": true,
+    "icon": "Puzzle"
+}

--- a/content/docs/established-information/network/meta.json
+++ b/content/docs/established-information/network/meta.json
@@ -1,0 +1,7 @@
+{
+    "title": "Network",
+    "pages": [
+        "..."
+    ],
+    "icon": "Globe"
+}

--- a/content/docs/established-information/network/packets/meta.json
+++ b/content/docs/established-information/network/packets/meta.json
@@ -1,0 +1,5 @@
+{
+    "title": "Packets",
+    "index": true,
+    "icon": "Package"
+}


### PR DESCRIPTION
# Pull Request

## Description

Pretty much self explanatory. Adds a network tab that holds the server / client's packet structure aswell as endpoints that may be accessed.

## Type of Change

- [ ] Documentation fix (typo, grammar, clarification)
- [x] New documentation (guide, tutorial, page)
- [ ] Bug fix
- [ ] New feature
- [ ] Other

## Related Issues

## Changes

- Adds a Network category within the Established Information Category
- Adds Packets & Endpoints tab to the category

## Checklist

- [x] Tested locally with `bun run dev`
- [x] Ran `bun audit` (no critical vulnerabilities)
- [x] Checked spelling and grammar
- [x] Verified all links work
- [x] Followed [Contributing Guidelines](https://github.com/HytaleModding/site/blob/main/CONTRIBUTING.md)

---

Thank you for contributing!

