### PR TITLE
GH-55: Add page transitions

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -41,6 +41,9 @@ const config = {
       },
     ];
   },
+  experimental: {
+    viewTransition: true,
+  },
 };
 
 export default withMDX(config);

--- a/src/app/(home)/layout.tsx
+++ b/src/app/(home)/layout.tsx
@@ -1,0 +1,9 @@
+import { ViewTransition } from "react";
+
+export default function HomeLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return <ViewTransition>{children}</ViewTransition>;
+}

--- a/src/app/[lang]/(home)/layout.tsx
+++ b/src/app/[lang]/(home)/layout.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from "react";
+import { ViewTransition, type ReactNode } from "react";
 import { HomeLayout } from "fumadocs-ui/layouts/home";
 import { baseOptions } from "@/lib/layout.shared";
 export default async function Layout({
@@ -9,5 +9,9 @@ export default async function Layout({
   children: ReactNode;
 }) {
   const { lang } = await params;
-  return <HomeLayout {...baseOptions(lang)}>{children}</HomeLayout>;
+  return (
+    <ViewTransition update="none">
+      <HomeLayout {...baseOptions(lang)}>{children}</HomeLayout>
+    </ViewTransition>
+  );
 }

--- a/src/app/[lang]/docs/[[...slug]]/page.tsx
+++ b/src/app/[lang]/docs/[[...slug]]/page.tsx
@@ -10,6 +10,7 @@ import { getMDXComponents } from "@/mdx-components";
 import type { Metadata } from "next";
 import { createRelativeLink } from "fumadocs-ui/mdx";
 import { branch } from "@/git-info.json";
+import { ViewTransition } from "react";
 
 export default async function Page(
   props: PageProps<"/[lang]/docs/[[...slug]]">,
@@ -21,27 +22,29 @@ export default async function Page(
   const MDX = page.data.body;
 
   return (
-    <DocsPage
-      toc={page.data.toc}
-      full={page.data.full}
-      editOnGithub={{
-        owner: "HytaleModding",
-        repo: "site",
-        path: `content/docs/${page.path}`,
-        sha: branch,
-      }}
-    >
-      <DocsTitle>{page.data.title}</DocsTitle>
-      <DocsDescription>{page.data.description}</DocsDescription>
-      <DocsBody>
-        <MDX
-          components={getMDXComponents({
-            // this allows you to link to other pages with relative file paths
-            a: createRelativeLink(source, page),
-          })}
-        />
-      </DocsBody>
-    </DocsPage>
+    <ViewTransition enter="docs-transition" exit="docs-transition">
+      <DocsPage
+        toc={page.data.toc}
+        full={page.data.full}
+        editOnGithub={{
+          owner: "HytaleModding",
+          repo: "site",
+          path: `content/docs/${page.path}`,
+          sha: branch,
+        }}
+      >
+        <DocsTitle>{page.data.title}</DocsTitle>
+        <DocsDescription>{page.data.description}</DocsDescription>
+        <DocsBody>
+          <MDX
+            components={getMDXComponents({
+              // this allows you to link to other pages with relative file paths
+              a: createRelativeLink(source, page),
+            })}
+          />
+        </DocsBody>
+      </DocsPage>
+    </ViewTransition>
   );
 }
 

--- a/src/app/[lang]/docs/docs.css
+++ b/src/app/[lang]/docs/docs.css
@@ -1,0 +1,36 @@
+::view-transition-group(.docs-transition) {
+}
+::view-transition-old(.docs-transition) {
+  animation: blur-scale-fade-out 0.3s cubic-bezier(0.455, 0.03, 0.515, 0.955);
+  animation-fill-mode: forwards;
+}
+::view-transition-new(.docs-transition) {
+  animation: blur-scale-fade-in 0.5s cubic-bezier(0.455, 0.03, 0.515, 0.955);
+  animation-fill-mode: forwards;
+}
+
+@keyframes blur-scale-fade-out {
+  from {
+    filter: blur(0);
+    transform: scale(1);
+    opacity: 1;
+  }
+  to {
+    filter: blur(4px);
+    transform: scale(1.05);
+    opacity: 0;
+  }
+}
+
+@keyframes blur-scale-fade-in {
+  from {
+    filter: blur(4px);
+    transform: scale(0.95);
+    opacity: 0;
+  }
+  to {
+    filter: blur(0);
+    transform: scale(1);
+    opacity: 1;
+  }
+}

--- a/src/app/[lang]/docs/layout.tsx
+++ b/src/app/[lang]/docs/layout.tsx
@@ -1,7 +1,10 @@
+import "./docs.css";
+
 import { DocsLayout } from "fumadocs-ui/layouts/docs";
 import { source } from "@/lib/source";
 import { baseOptions } from "@/lib/layout.shared";
 import { DocsBanner } from "./docs-banner";
+import { ViewTransition } from "react";
 
 export default async function Layout({
   params,
@@ -10,15 +13,17 @@ export default async function Layout({
   const { lang } = await params;
 
   return (
-    <div className="flex min-h-screen flex-col">
-      <DocsBanner />
-      <DocsLayout
-        tree={source.pageTree[lang]}
-        {...baseOptions(lang)}
-        githubUrl="https://github.com/HytaleModding/site"
-      >
-        {children}
-      </DocsLayout>
-    </div>
+    <ViewTransition update="none">
+      <div className="flex min-h-screen flex-col">
+        <DocsBanner />
+        <DocsLayout
+          tree={source.pageTree[lang]}
+          {...baseOptions(lang)}
+          githubUrl="https://github.com/HytaleModding/site"
+        >
+          {children}
+        </DocsLayout>
+      </div>
+    </ViewTransition>
   );
 }


### PR DESCRIPTION
# Pull Request

## Description

Brief description of what this PR does.

## Type of Change

- [ ] Documentation fix (typo, grammar, clarification)
- [ ] New documentation (guide, tutorial, page)
- [ ] Bug fix
- [x] New feature
- [ ] Other

## Related Issues

Fixes #55 

## Changes

- Enable ViewTransitionsAPI
- Add a custom view transition
- Add transitions to docs page and between docs and home

## Screenshots

If applicable, add before/after screenshots:

After:
https://github.com/user-attachments/assets/c7953da3-421b-426b-be98-d143cb03dd67

## Checklist

- [x] Tested locally with `bun run dev`
- [x] Ran `bun audit` (no critical vulnerabilities)
- [x] Checked spelling and grammar
- [x] Verified all links work
- [x] Followed [Contributing Guidelines](../CONTRIBUTING.md)

---

Thank you for contributing!
 gh-55
