### PR TITLE
Fix animation for connected scripts

### DIFF
--- a/src/components/ui/flip-words.tsx
+++ b/src/components/ui/flip-words.tsx
@@ -84,7 +84,7 @@ export const FlipWords = ({
                 animate={{ opacity: 1, y: 0, filter: "blur(0px)" }}
                 transition={{
                   delay: wordIndex * 0.3,
-                  duration: 0.3,
+                  duration: 0.2,
                 }}
                 className="inline-block"
               >


### PR DESCRIPTION
# Pull Request

## Description

Fix text animation to properly handle connected scripts. their words now animate as a whole instead of splitting letters.

## Type of Change

- [ ] Documentation fix (typo, grammar, clarification)
- [ ] New documentation (guide, tutorial, page)
- [x] Bug fix
- [ ] New feature
- [ ] Other

## Related Issues

Fixes #(issue)

## Changes

- Updated src/components/ui/flip-words.tsx to detect connected scripts.
- Animate connected scripts as whole words instead of splitting letters.
- Retain per-letter animation for other scripts.

## Screenshots

<img width="1920" height="919" alt="brave_h3m2RYbWeJ" src="https://github.com/user-attachments/assets/b28c9d2a-ffc4-49ee-91b2-7583225ecc0d" />

<img width="1920" height="919" alt="brave_NSFVRFZwOT" src="https://github.com/user-attachments/assets/454f955a-aebc-4a8a-87d1-6f3d20c07427" />


<img width="1920" height="919" alt="brave_9GsI604oDm" src="https://github.com/user-attachments/assets/e953461e-3b6a-4fe3-8251-aa549a4c941d" />

<img width="1920" height="919" alt="brave_alI3VeFrpR" src="https://github.com/user-attachments/assets/92ee235d-aad8-411a-972d-6aa7d6ab2c70" />

## Checklist

- [x] Tested locally with `bun run dev`
- [ ] Ran `bun audit` (no critical vulnerabilities)
- [ ] Checked spelling and grammar
- [ ] Verified all links work
- [x] Followed [Contributing Guidelines](../CONTRIBUTING.md)

---

Thank you for contributing!
