### PR TITLE
GH-78 Fix home page title extra space

### DIFF
--- a/src/components/ui/flip-words.tsx
+++ b/src/components/ui/flip-words.tsx
@@ -61,7 +61,7 @@ export const FlipWords = ({
           position: "absolute",
         }}
         className={cn(
-          "relative z-10 inline-block px-2 text-left text-neutral-900 dark:text-neutral-100",
+          "relative z-10 inline-block text-left text-neutral-900 dark:text-neutral-100",
           className,
         )}
         key={currentWord}


### PR DESCRIPTION
# Pull Request

## Description

Fix the extra space in the home page title. 

## Type of Change

- [ ] Documentation fix (typo, grammar, clarification)
- [ ] New documentation (guide, tutorial, page)
- [x] Bug fix
- [ ] New feature
- [ ] Other

## Related Issues

Fixes #78 

## Changes

- Remove the x padding of the flip words effect

## Screenshots

Before:

<img width="548" height="112" alt="image" src="https://github.com/user-attachments/assets/7f9b345a-e7e5-40a4-be2a-5dd541541504" />

After:

<img width="451" height="101" alt="image" src="https://github.com/user-attachments/assets/0285e752-6368-4967-8516-62f93aa73ad3" />


## Checklist

- [x] Tested locally with `bun run dev`
- [x] Ran `bun audit` (no critical vulnerabilities)
- [x] Checked spelling and grammar
- [x] Verified all links work
- [x] Followed [Contributing Guidelines](../CONTRIBUTING.md)

---

Thank you for contributing!
 gh-78
