### PR TITLE
fix: support widget growing out of boundaries

### DIFF
--- a/src/app/[lang]/(home)/support-button.tsx
+++ b/src/app/[lang]/(home)/support-button.tsx
@@ -16,8 +16,6 @@ import { useParams } from "next/navigation";
 import { AnimatePresence, motion } from "motion/react";
 import { Sponsor } from "@/lib/types/sponsor";
 
-
-
 export function SponsorButton() {
   const messages = useMessages();
   const params = useParams();
@@ -130,7 +128,7 @@ export function SponsorButton() {
                       title={`+ ${sponsorsList.length - displayedSponsors.length}`}
                     >
                       <AvatarFallback>
-                        {`+ ${sponsorsList.length - displayedSponsors.length}`}
+                        {`+${sponsorsList.length >= 10 + MAX_DISPLAY ? "" : " "}${sponsorsList.length - displayedSponsors.length}`}
                       </AvatarFallback>
                     </Avatar>
                   </motion.div>


### PR DESCRIPTION
# Pull Request

## Description

Removes the spacing between the "+" and the number when over 1 digit to fit in boundries

## Type of Change

- [ ] Documentation fix (typo, grammar, clarification)
- [ ] New documentation (guide, tutorial, page)
- [x] Bug fix
- [ ] New feature
- [ ] Other

## Screenshots

If applicable, add before/after screenshots:

## Checklist

- [x] Tested locally with `bun run dev`
- [x] Ran `bun audit` (no critical vulnerabilities)
- [x] Checked spelling and grammar
- [x] Verified all links work
- [x] Followed [Contributing Guidelines](../CONTRIBUTING.md)

---

Thank you for contributing!


fixes: GH-132
issue: #132