### PR TITLE
fix: change 'Getting Started' guide hyperlink to link to the correct…

### DIFF
--- a/content/docs/en/guides/3d-modeling/starting-out.mdx
+++ b/content/docs/en/guides/3d-modeling/starting-out.mdx
@@ -5,7 +5,7 @@ authors:
       url: https://itsneil.dev
 ---
 
-Please complete the [Getting Started](./getting-started.mdx) guide before this.
+Please complete the [Getting Started](./getting-started) guide before this.
 
 Once you have completed the Getting Started guide, you should have a Hytale Prop model ready to go. In this guide, we will cover how to create an actual model using Blockbench.
 


### PR DESCRIPTION
… page instead of a 404 error page

# Pull Request

## Description

Fixes 404 error redirect when clicking on 'Getting Started' hyperlink in the 'Starting Out with 3D Modeling' guide.

## Type of Change

- [x] Documentation fix (typo, grammar, clarification)
- [ ] New documentation (guide, tutorial, page)
- [x] Bug fix
- [ ] New feature
- [ ] Other

## Screenshots

If applicable, add before/after screenshots:

## Checklist

- [x] Tested locally with `bun run dev`
- [x] Ran `bun audit` (no critical vulnerabilities)
- [x] Checked spelling and grammar
- [x] Verified all links work
- [x] Followed [Contributing Guidelines](../CONTRIBUTING.md)

---

Thank you for contributing!
