### PR TITLE
GH-155: fix: download only approved translations

### DIFF
--- a/.github/workflows/crowdin-download.yml
+++ b/.github/workflows/crowdin-download.yml
@@ -20,6 +20,7 @@ jobs:
           upload_translations: false
           download_translations: true
           create_pull_request: true
+          export_only_approved: true
           pull_request_title: "New translations from Crowdin"
           pull_request_body: "Completed translations have been downloaded."
           localization_branch_name: crowdin-translations


### PR DESCRIPTION
# Pull Request

## Description

Only download approved translations from Crowdin instead of all translations.

## Type of Change

- [ ] Documentation fix (typo, grammar, clarification)
- [ ] New documentation (guide, tutorial, page)
- [x] Bug fix
- [ ] New feature
- [ ] Other

## Screenshots

If applicable, add before/after screenshots:

## Checklist

- [ ] Tested locally with `bun run dev`
- [ ] Ran `bun audit` (no critical vulnerabilities)
- [x] Checked spelling and grammar
- [ ] Verified all links work
- [x] Followed [Contributing Guidelines](../CONTRIBUTING.md)

---

Thank you for contributing!
 gh-155
