### PR TITLE
GH-181 fix: Correct Polish language label

### DIFF
--- a/messages/pl-PL.json
+++ b/messages/pl-PL.json
@@ -1,5 +1,5 @@
 {
-  "displayName": "Angielski",
+  "displayName": "Polski",
   "nav": {
     "title": "Modyfikacje Hytale",
     "documentation": "Dokumentacja",


### PR DESCRIPTION
Fixed a typo where Polish language was labeled as 'Angielski'. gh-181
