### PR TITLE
Fixed missing PlayerAnimationId in Block guide

### DIFF
--- a/content/docs/en/guides/plugin/creating-block.mdx
+++ b/content/docs/en/guides/plugin/creating-block.mdx
@@ -56,6 +56,7 @@ Create `Server/Item/Items/my_new_block.json`:
         "Description": "items.my_new_block.description"
     },
     "Id": "MyNewBlock",
+    "PlayerAnimationsId": "Block",
     "MaxStack": 20,
     "BlockType": {
         "Material": "Solid",
@@ -83,6 +84,7 @@ For custom models, use `DrawType: "Model"`:
         "Description": "items.my_new_block.description"
     },
     "Id": "MyNewBlock",
+    "PlayerAnimationsId": "Block",
     "MaxStack": 20,
     "BlockType": {
         "Material": "Solid",


### PR DESCRIPTION
# Pull Request

## Description

Added the PlayerAnimationId to allow a block being placed as mentioned by Blight on Discord

## Type of Change

- [x] Documentation fix (typo, grammar, clarification)

## Checklist

- [x] Tested locally with `bun run dev`
- [x] Ran `bun audit` (no critical vulnerabilities)
- [x] Checked spelling and grammar
- [x] Verified all links work
- [x] Followed [Contributing Guidelines](../CONTRIBUTING.md)