### PR TITLE
Fix link to docs/guides/plugin/setting-up-env

### DIFF
--- a/content/docs/en/quick-start.mdx
+++ b/content/docs/en/quick-start.mdx
@@ -6,6 +6,6 @@ description: Setting up a standard Hytale project.
 Welcome to the Hytale modding documentation! Here you'll find everything you need to know about creating your own mods for Hytale.
 
 - [Java Basics](./guides/java-basics/00-introduction)
-- [Setting up your dev environment](./guides/dev-environment)
+- [Setting up your dev environment](./guides/plugin/setting-up-env)
 - [Entity Component System (ECS)](./guides/ecs)
 - [Publishing your mod](./guides/publishing)


### PR DESCRIPTION
# Pull Request

## Description
The link to Setting up your dev environment on /docs/quick-start led to a 404, but now it leads to the correct page.
```diff
-- [Setting up your dev environment](./guides/dev-environment)
+- [Setting up your dev environment](./guides/plugin/setting-up-env)
```

## Type of Change

- [x] Documentation fix (typo, grammar, clarification)
- [ ] New documentation (guide, tutorial, page)
- [ ] Bug fix
- [ ] New feature
- [ ] Other

## Screenshots

If applicable, add before/after screenshots:

## Checklist

- [x] Tested locally with `bun run dev`
- [x] Ran `bun audit` (no critical vulnerabilities)
- [x] Checked spelling and grammar
- [x] Verified all links work
- [x] Followed [Contributing Guidelines](../CONTRIBUTING.md)

---

Thank you for contributing!
