### PR TITLE
style: format misformatted json files

### DIFF
--- a/content/docs/en/guides/ecs/meta.json
+++ b/content/docs/en/guides/ecs/meta.json
@@ -1,6 +1,4 @@
 {
   "icon": "IdCardLanyard",
-  "pages": [
-    "hytale-ecs.mdx"
-  ]
+  "pages": ["hytale-ecs.mdx"]
 }

--- a/content/docs/en/guides/plugin/meta.json
+++ b/content/docs/en/guides/plugin/meta.json
@@ -1,12 +1,12 @@
 {
-    "title": "Server Plugins",
-    "pages": [
-        "setting-up-env.mdx",
-        "browsing-serverjar.mdx",
-        "creating-commands.mdx",
-        "creating-events.mdx",
-        "chat-formatting.mdx",
-        "..."
-    ],
-    "icon": "Terminal"
+  "title": "Server Plugins",
+  "pages": [
+    "setting-up-env.mdx",
+    "browsing-serverjar.mdx",
+    "creating-commands.mdx",
+    "creating-events.mdx",
+    "chat-formatting.mdx",
+    "..."
+  ],
+  "icon": "Terminal"
 }


### PR DESCRIPTION
# Pull Request

## Description

The meta.json files were misformatted after these commits: 58ffa0606b61b6675047f0eb6d4af877f188a494 (from PR #202) and ff1d11c1c578da49b79a5b7882e7e5112edaa943

## Type of Change

- [ ] Documentation fix (typo, grammar, clarification)
- [ ] New documentation (guide, tutorial, page)
- [ ] Bug fix
- [ ] New feature
- [x] Other

## Screenshots

If applicable, add before/after screenshots:

## Checklist

- [x] Tested locally with `bun run dev`
- [x] Ran `bun audit` (no critical vulnerabilities)
- [x] Checked spelling and grammar
- [x] Verified all links work
- [x] Followed [Contributing Guidelines](../CONTRIBUTING.md)

---

Thank you for contributing!
