### PR TITLE
GH-226 Add Tools documentation section

### DIFF
--- a/content/docs/en/meta.json
+++ b/content/docs/en/meta.json
@@ -7,6 +7,8 @@
     "...guides",
     "---Documentation---",
     "...server",
+    "---Tools---",
+    "...tools",
     "---Community---",
     "publishing",
     "projects",

--- a/content/docs/en/tools/meta.json
+++ b/content/docs/en/tools/meta.json
@@ -1,0 +1,7 @@
+{
+  "title": "Tools",
+  "pages": [
+    "hytale-asset-index"
+  ],
+  "icon": "GraduationCap"
+}


### PR DESCRIPTION
# Pull Request

## Description

Adds a **Tools** section to the documentation sidebar and establishes the structure for documenting modding-related tools.

This change introduces the navigation grouping and metadata required to host tool documentation in a consistent, discoverable location.

## Type of Change

* [ ] Documentation fix (typo, grammar, clarification)
* [x] New documentation (guide, tutorial, page)
* [ ] Bug fix
* [x] New feature
* [ ] Other

## Screenshots

N/A — navigation-only change.

## Checklist

* [x] Tested locally with `bun run dev`
* [ ] Ran `bun audit` (not required for documentation-only changes)
* [x] Checked spelling and grammar
* [x] Verified all links work
* [x] Followed [Contributing Guidelines](../CONTRIBUTING.md) gh-226
