### PR TITLE
fix: add language pages to sitemap

### DIFF
--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,4 +1,5 @@
 import { source } from "@/lib/source";
+import { i18n } from "@/lib/i18n";
 import { readdir } from "fs/promises";
 import { join } from "path";
 import type { MetadataRoute } from "next";
@@ -8,12 +9,15 @@ const baseUrl = "https://hytalemodding.dev";
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const sitemap: MetadataRoute.Sitemap = [];
 
-  sitemap.push({
-    url: baseUrl,
-    lastModified: new Date(),
-    changeFrequency: "daily",
-    priority: 1.0,
-  });
+  // Add all language home pages
+  for (const lang of i18n.languages) {
+    sitemap.push({
+      url: `${baseUrl}/${lang}`,
+      lastModified: new Date(),
+      changeFrequency: "daily",
+      priority: lang === i18n.defaultLanguage ? 1.0 : 0.95,
+    });
+  }
 
   // Get all pages from source
   const pages = source.getPages();
@@ -43,22 +47,22 @@ async function addProjectPages(sitemap: MetadataRoute.Sitemap) {
     const mdxFiles = files.filter(
       (file) => file.endsWith(".mdx") && file !== "example.mdx",
     );
-
-    sitemap.push({
-      url: `${baseUrl}/en/projects`,
-      lastModified: new Date(),
-      changeFrequency: "weekly",
-      priority: 0.9,
-    });
-
-    for (const file of mdxFiles) {
-      const slug = file.replace(/\.mdx$/, "");
+    for (const lang of i18n.languages) {
       sitemap.push({
-        url: `${baseUrl}/en/projects/${slug}`,
+        url: `${baseUrl}/${lang}/projects`,
         lastModified: new Date(),
-        changeFrequency: "monthly",
-        priority: 0.7,
+        changeFrequency: "weekly",
+        priority: 0.9,
       });
+      for (const file of mdxFiles) {
+        const slug = file.replace(/\.mdx$/, "");
+        sitemap.push({
+          url: `${baseUrl}/${lang}/projects/${slug}`,
+          lastModified: new Date(),
+          changeFrequency: "weekly",
+          priority: 0.7,
+        });
+      }
     }
   } catch (error) {
     console.error("Error reading projects for sitemap:", error);


### PR DESCRIPTION
# Pull Request

## Description

Current sitemap does not include the language variations of pages, added for them to also get indexed.

## Type of Change

- [ ] Documentation fix (typo, grammar, clarification)
- [ ] New documentation (guide, tutorial, page)
- [x] Bug fix
- [ ] New feature
- [ ] Other

## Screenshots

If applicable, add before/after screenshots:

## Checklist

- [x] Tested locally with `bun run dev`
- [x] Ran `bun audit` (no critical vulnerabilities)
- [x] Checked spelling and grammar
- [x] Verified all links work
- [x] Followed [Contributing Guidelines](../CONTRIBUTING.md)

---

Thank you for contributing!
