### PR TITLE
Edit default keybinds to match version 2026.01.15-c04fdfe10

### DIFF
--- a/content/docs/en/guides/plugin/player-input-guide.mdx
+++ b/content/docs/en/guides/plugin/player-input-guide.mdx
@@ -39,13 +39,13 @@ Due to the use of `packets` not key inputs, you cannot assign your custom Fireba
 | Left Mouse | LMB | `InteractionType.Primary` | Attack/break |
 | Right Mouse | RMB | `InteractionType.Secondary` | Use/place |
 | Weapon Ability | Q | `InteractionType.Ability1` | Active - weapon special |
-| Ability Slot 2 | — | `InteractionType.Ability2` | Unused placeholder |
-| Ability Slot 3 | — | `InteractionType.Ability3` | Unused placeholder |
-| Interact | E | `InteractionType.Use` | Interact with world |
+| Ability Slot 2 | E | `InteractionType.Ability2` | Unused placeholder |
+| Ability Slot 3 | R | `InteractionType.Ability3` | Unused placeholder |
+| Interact | F | `InteractionType.Use` | Interact with world |
 | Pick Block | MMB | `InteractionType.Pick` | Copy block type |
-| Dodge | — | `InteractionType.Dodge` | Dodge roll mechanic |
+| Dodge | LCTRL | `InteractionType.Dodge` | Dodge roll mechanic |
 
-**Note:** Only `Ability1` (Q key) is actively used for weapon abilities. `Ability2` and `Ability3` exist in the enum but have no default keybinds and nothing in the codebase references them: they appear to be reserved for future use.
+**Note:** Only `Ability1` (Q key) is actively used for weapon abilities. `Ability2` and `Ability3` exist in the enum but nothing in the codebase references them: they appear to be reserved for future use.
 
 These are the only keyboard actions the server sees.
 


### PR DESCRIPTION
Edit default keybinds to match version 2026.01.13-50E69C385 and possibly some previous versions

# Pull Request

## Description

Replaces and adds default keybinds to match in game default keybinds in version 2026.01.13-50E69C385

## Type of Change

- [x] Documentation fix (typo, grammar, clarification)
- [ ] New documentation (guide, tutorial, page)
- [ ] Bug fix
- [ ] New feature
- [ ] Other

## Screenshots

If applicable, add before/after screenshots:
Current guide
<img width="836" height="406" alt="Screenshot 2026-01-15 at 15-11-39 Player Input and Keybind Guide" src="https://github.com/user-attachments/assets/eb97b553-596a-4c96-88ac-1f48f54bc88d" />

Default keybinds in game in version 2026.01.13-50E69C385
<img width="1212" height="272" alt="image" src="https://github.com/user-attachments/assets/d550535d-45cf-4e89-ad63-ae7254101b25" />
<img width="1141" height="73" alt="image" src="https://github.com/user-attachments/assets/ac8d398d-a6ae-4ff8-a8db-75ff989f3d8a" />



## Checklist

- [x] Tested locally with `bun run dev`
- [x] Ran `bun audit` (no critical vulnerabilities)
- [x] Checked spelling and grammar
- [x] Verified all links work
- [x] Followed [Contributing Guidelines](../CONTRIBUTING.md)

---

Thank you for contributing!
