### PR TITLE
GH-262 Added java troubleshooting on fresh install

### DIFF
--- a/content/docs/en/guides/plugin/setting-up-env.mdx
+++ b/content/docs/en/guides/plugin/setting-up-env.mdx
@@ -34,14 +34,14 @@ java -version
 ```bash
 # Using Homebrew
 brew install openjdk@25
-
-# Add OpenJDK to your PATH (required for java command to work)
-echo 'export PATH="$(brew --prefix)/opt/openjdk@25/bin:$PATH"' >> ~/.zshrc
-source ~/.zshrc
 ```
 
 <Callout type="info">
-If `java --version` shows "Unable to locate a Java Runtime", run the PATH commands above. This adds OpenJDK to your shell configuration (`~/.zshrc`).
+If `java --version` shows "Unable to locate a Java Runtime", add OpenJDK to your PATH:
+```bash
+echo 'export PATH="$(brew --prefix)/opt/openjdk@25/bin:$PATH"' >> ~/.zshrc
+source ~/.zshrc
+```
 </Callout>
 
 #### Linux (Ubuntu/Debian)
@@ -49,10 +49,6 @@ If `java --version` shows "Unable to locate a Java Runtime", run the PATH comman
 sudo apt update
 sudo apt install openjdk-25-jdk
 ```
-
-<Callout type="info">
-If `java --version` doesn't work after installation, you may need to log out and back in, or run `source ~/.bashrc` to refresh your shell environment.
-</Callout>
 
 ### 2. Integrated Development Environment (IDE)
 


### PR DESCRIPTION
# Pull Request

## Description

 Add PATH configuration instructions for Homebrew OpenJDK installation on macOS. When users install OpenJDK via Homebrew, running `java --version` may fail with "Unable to locate a Java Runtime" because Homebrew doesn't automatically add OpenJDK to the PATH.

Changes:
  - Added PATH export commands to the macOS installation section
  - Added info callout explaining how to fix the "Unable to locate a Java Runtime" error
  - Added info callout for Linux about refreshing the shell environment after installation
  - Applied changes to all 23 language versions of `setting-up-env.mdx`

  Closes #262

## Type of Change

  - [x] Documentation fix (typo, grammar, clarification)
  - [ ] New documentation (guide, tutorial, page)
  - [ ] Bug fix
  - [ ] New feature
  - [ ] Other gh-262
