### PR TITLE
Fix typo: ESC to ECS in event documentation

### DIFF
--- a/content/docs/en/guides/plugin/creating-events.mdx
+++ b/content/docs/en/guides/plugin/creating-events.mdx
@@ -39,9 +39,9 @@ public class MyPlugin extends JavaPlugin {
 }
 ```
 
-## ESC Event Classes
+## ECS Event Classes
 
-For events that fall under the [ESC Events](../../server/events#ecsevent) list you will need to instead create and register an entity event system.
+For events that fall under the [ECS Events](../../server/events#ecsevent) list you will need to instead create and register an entity event system.
 An example is included below that will cancel the crafting of a recipe if it uses fibre as an input.
 
 ```java
@@ -74,7 +74,7 @@ class ExampleCancelCraft extends EntityEventSystem<EntityStore, CraftRecipeEvent
 }
 ```
 
-## Registering ESC Events
+## Registering ECS Events
 
 You will need to register the system in your plugin:
 


### PR DESCRIPTION
# Pull Request

## Description

Fixed a small Typo.

## Type of Change

- [X] Documentation fix (typo, grammar, clarification)
- [ ] New documentation (guide, tutorial, page)
- [ ] Bug fix
- [ ] New feature
- [ ] Other

## Screenshots

If applicable, add before/after screenshots:

## Checklist

- [ ] Tested locally with `bun run dev`
- [ ] Ran `bun audit` (no critical vulnerabilities)
- [X] Checked spelling and grammar
- [ ] Verified all links work
- [ ] Followed [Contributing Guidelines](../CONTRIBUTING.md)

---

Thank you for contributing!
