### PR TITLE
fix author links

### DIFF
--- a/content/docs/en/guides/plugin/listening-to-packets.mdx
+++ b/content/docs/en/guides/plugin/listening-to-packets.mdx
@@ -3,9 +3,9 @@ title: "Listening to Packets"
 description: "Learn how to listen to packets that are sent or received from the Client"
 authors:
     - name: Neil Revin
-      link: https://itsneil.dev
-    - name: Musava Ribica
-      link: https://forum.hytalemodding.dev/u/musava_ribica
+      url: https://itsneil.dev
+    - name: musava_ribica
+      url: https://forum.hytalemodding.dev/u/musava_ribica
 ---
 
 In this guide, you'll learn how to listen to packets that are being sent or received from the Client.


### PR DESCRIPTION
# Pull Request

## Description

Changed `link` to `url` because `link` doesn't do anything. Changed my username. "Musava Ribica" is not my real name just a handle I use on social media, the correct *spellings* are musava_ribica and IamMusavaRibica (first is uppercase i)

## Type of Change

- [x] Documentation fix (typo, grammar, clarification)
- [ ] New documentation (guide, tutorial, page)
- [ ] Bug fix
- [ ] New feature
- [ ] Other

## Screenshots

If applicable, add before/after screenshots:

## Checklist

- [ ] Tested locally with `bun run dev`
- [ ] Ran `bun audit` (no critical vulnerabilities)
- [x] Checked spelling and grammar
- [x] Verified all links work
- [ ] Followed [Contributing Guidelines](../CONTRIBUTING.md)

---

Thank you for contributing!
