### PR TITLE
GH-272 Fix outdated teleportation Code example

### DIFF
--- a/content/docs/en/guides/plugin/teleporting-players.mdx
+++ b/content/docs/en/guides/plugin/teleporting-players.mdx
@@ -14,7 +14,10 @@ public static void teleportPlayer(Player player, int x, int y, int z) {
         world.execute(() -> {
             if (player.getReference() == null) return;
             Store<EntityStore> store = player.getReference().getStore();
-            Teleport teleport = new Teleport(new Transform(x ,y, z));
+            Teleport teleport = new Teleport(
+                new Vector3d(x ,y, z), // Target position
+                new Vector3f(0, 0, 0)  // Target rotation (pitch, yaw, roll)
+            );
 
             store.addComponent(player.getReference(), Teleport.getComponentType(), teleport);
         });


### PR DESCRIPTION
## Description

The release of Hytale version `Version: 2026.01.17-4b0f30090` causes changes inside the Teleport class. Instead of using Transform, the constructor expects position and rotation as parameters.

## Type of Change

- [x] Documentation fix (typo, grammar, clarification)
- [ ] New documentation (guide, tutorial, page)
- [ ] Bug fix
- [ ] New feature
- [ ] Other

## Checklist

- [x] Tested locally with `bun run dev`
- [x] Ran `bun audit` (no critical vulnerabilities)
- [x] Checked spelling and grammar
- [x] Verified all links work
- [x] Followed [Contributing Guidelines](../CONTRIBUTING.md)

---

Thank you for contributing!
 gh-272
