### PR TITLE
chore: remove logging for loading translations

### DIFF
--- a/src/lib/tree-localization.ts
+++ b/src/lib/tree-localization.ts
@@ -9,8 +9,6 @@ export function localizePageTree(
 ): DocsLayoutProps["tree"] {
   let translations = FallbackLanguage;
 
-  console.log("Loading translations for lang:", lang);
-
   if (lang !== "en") {
     const langFilePath = path.join(process.cwd(), "messages", `${lang}.json`);
     if (fs.existsSync(langFilePath)) {


### PR DESCRIPTION
# Pull Request

## Description

It spams "Loading translations for: x" in the logs and is a left-over `console.log()` anyways. Isn't providing any valuable logs currently, just filling up logs.

## Type of Change

- [ ] Documentation fix (typo, grammar, clarification)
- [ ] New documentation (guide, tutorial, page)
- [ ] Bug fix
- [ ] New feature
- [x] Other

## Screenshots

If applicable, add before/after screenshots:

## Checklist

- [x] Tested locally with `bun run dev`
- [x] Ran `bun audit` (no critical vulnerabilities)
- [x] Checked spelling and grammar
- [x] Verified all links work
- [x] Followed [Contributing Guidelines](../CONTRIBUTING.md)

---

Thank you for contributing!
