### PR TITLE
feat: replace docs transition with something a little less disorienting

### DIFF
--- a/src/app/[lang]/docs/[[...slug]]/page.tsx
+++ b/src/app/[lang]/docs/[[...slug]]/page.tsx
@@ -33,22 +33,26 @@ export default async function Page(
   const authors = page.data.authors;
 
   return (
-    <ViewTransition enter="blur-scale-transition" exit="blur-scale-transition">
-      <DocsPage
-        toc={page.data.toc}
-        tableOfContent={{
-          style: "clerk",
-        }}
-        full={page.data.full}
-        editOnGithub={{
-          owner: "HytaleModding",
-          repo: "site",
-          path: `content/docs/${page.path}`,
-          sha: branch,
-        }}
-      >
+    <DocsPage
+      toc={page.data.toc}
+      tableOfContent={{
+        style: "clerk",
+      }}
+      full={page.data.full}
+      editOnGithub={{
+        owner: "HytaleModding",
+        repo: "site",
+        path: `content/docs/${page.path}`,
+        sha: branch,
+      }}
+    >
+      <ViewTransition name="docs-title">
         <DocsTitle>{page.data.title}</DocsTitle>
+      </ViewTransition>
+      <ViewTransition name="docs-desc">
         <DocsDescription>{page.data.description}</DocsDescription>
+      </ViewTransition>
+      <ViewTransition name="docs-body">
         <DocsBody>
           <MDX
             components={getMDXComponents({
@@ -83,8 +87,8 @@ export default async function Page(
         )}
 
         {/* {lastModified && <PageLastUpdate date={lastModified} />} */}
-      </DocsPage>
-    </ViewTransition>
+      </ViewTransition>
+    </DocsPage>
   );
 }
 


### PR DESCRIPTION
# Pull Request

## Description

The current docs transition is a bit disorienting. Here's a version using default ViewTransition animations.

## Type of Change

- [ ] Documentation fix (typo, grammar, clarification)
- [ ] New documentation (guide, tutorial, page)
- [ ] Bug fix
- [ ] New feature
- [x] Other

## Screenshots

If applicable, add before/after screenshots:

## Checklist

- [x] Tested locally with `bun run dev`
- [x] Ran `bun audit` (no critical vulnerabilities)
- [x] Checked spelling and grammar
- [x] Verified all links work
- [x] Followed [Contributing Guidelines](../CONTRIBUTING.md)

---

Thank you for contributing!
