### PR TITLE
GH-332: update links in quick-start to correct paths

### DIFF
--- a/content/docs/en/quick-start.mdx
+++ b/content/docs/en/quick-start.mdx
@@ -7,5 +7,5 @@ Welcome to the Hytale modding documentation! Here you'll find everything you nee
 
 - [Java Basics](./guides/java-basics/00-introduction)
 - [Setting up your dev environment](./guides/plugin/setting-up-env)
-- [Entity Component System (ECS)](./guides/ecs)
-- [Publishing your mod](./guides/publishing)
+- [Entity Component System (ECS)](./guides/ecs/entity-component-system)
+- [Publishing your mod](./publishing)


### PR DESCRIPTION
## Description

Some quickstart paths where outdated due to changes made in the documentation structures. This PR focuses on adjusting the links to the correct ones.

## Type of Change

- [x] Documentation fix (typo, grammar, clarification)
- [ ] New documentation (guide, tutorial, page)
- [x] Bug fix
- [ ] New feature
- [ ] Other

## Checklist

- [x] Tested locally with `bun run dev`
- [x] Ran `bun audit` (no critical vulnerabilities)
- [x] Checked spelling and grammar
- [x] Verified all links work
- [x] Followed [Contributing Guidelines](../CONTRIBUTING.md)

---

Closes #332

Thank you for contributing!
