### PR TITLE
GH-347 change tinymessage documentation to use repository

### DIFF
--- a/content/docs/en/guides/plugin/chat-formatting.mdx
+++ b/content/docs/en/guides/plugin/chat-formatting.mdx
@@ -123,10 +123,6 @@ Download the latest TinyMessage.jar from the releases page and place it in your 
 
 ## Installation for developers:
 
-Temporary until hytale plugin repository is available.
-Create libs folder in your plugin directory and place the TinyMsg jar file there.
-project/libs/TinyMessage-2.0.0-SNAPSHOT.jar
-
 ### manifest.json
 ```json
 "Dependencies": {
@@ -136,19 +132,29 @@ project/libs/TinyMessage-2.0.0-SNAPSHOT.jar
 
 ### For Gradle
 ```kotlin
+repositories {
+    maven { url = uri("https://jitpack.io") }
+}
+
 dependencies {
-    compileOnly(files("libs/tinymessage-2.0.0-SNAPSHOT.jar"))
+    compileOnly("com.github.Zoltus:TinyMessage:2.0.1") // Use newest version in the repo
 }
 ```
 
 ### For Maven
 ```xml
+<repositories>
+    <repository>
+        <id>jitpack.io</id>
+        <url>https://jitpack.io</url>
+    </repository>
+</repositories>
+
 <dependency>
-    <groupId>fi.sulku.hytale</groupId>
-    <artifactId>tinymessage</artifactId>
-    <version>2.0.0</version>
+    <groupId>com.github.Zoltus</groupId>
+    <artifactId>TinyMessage</artifactId>
+    <version>2.0.1</version>
     <scope>provided</scope>
-    <systemPath>${project.basedir}/libs/tinymessage-2.0.0-SNAPSHOT.jar</systemPath>
 </dependency>
 ```
 


### PR DESCRIPTION
# Pull Request

## Description

Add repository instructions for TinyMessage, previously it was possible to only use it's api as local jar.

## Type of Change

- [ ] Documentation fix (typo, grammar, clarification)
- [ ] New documentation (guide, tutorial, page)
- [X] Bug fix
- [ ] New feature
- [ ] Other

## Screenshots

If applicable, add before/after screenshots:

## Checklist

- [X] Tested locally with `bun run dev`
- [X] Ran `bun audit` (no critical vulnerabilities)
- [X] Checked spelling and grammar
- [X] Verified all links work
- [X] Followed [Contributing Guidelines](../CONTRIBUTING.md)

---

Thank you for contributing!
 gh-347
