### PR TITLE
fixes #354 : Create configuration file code example does not work

### DIFF
--- a/content/docs/en/guides/plugin/creating-configuration-file.mdx
+++ b/content/docs/en/guides/plugin/creating-configuration-file.mdx
@@ -64,11 +64,7 @@ In your project's `JavaPlugin` class, you should load the configuration file in 
 You should also call `save()` on the `Config<T>` in the setup, to ensure that the configuration file is created if it doesn't exist.
 ```java
 public class ExamplePlugin extends JavaPlugin {
-    private final Config<MyConfig> config;
-
-    public ExamplePlugin(){
-        config = this.withConfig("MyConfig", MyConfig.CODEC);
-    }
+    private final Config<MyConfig> config = this.withConfig("MyConfig", MyConfig.CODEC);
 
     @Override
     public void setup() {


### PR DESCRIPTION
# Pull Request

## Description

Fixes issue #354 (Create configuration file code example does not work).

## Type of Change

- [ ] Documentation fix (typo, grammar, clarification)
- [ ] New documentation (guide, tutorial, page)
- [X] Bug fix
- [ ] New feature
- [ ] Other

## Screenshots

N/A

## Checklist

- [X] Tested locally with `bun run dev`
- [X] Ran `bun audit` (no critical vulnerabilities)
- [X] Checked spelling and grammar
- [X] Verified all links work
- [X] Followed [Contributing Guidelines](../CONTRIBUTING.md)

---

Thank you for contributing!
 gh-354
