### PR TITLE
Fixed class name mismatch in Block Components

### DIFF
--- a/content/docs/en/guides/plugin/block-components.mdx
+++ b/content/docs/en/guides/plugin/block-components.mdx
@@ -86,7 +86,7 @@ public class ExampleInitializer extends RefSystem {
 }
 ```
 
-ExampleSystemInitializer is a RefSystem that reacts when block entities with the ExampleBlock component are added or removed. This is crucial for marking blocks as ticking when they're first placed.
+ExampleInitializer is a RefSystem that reacts when block entities with the ExampleBlock component are added or removed. This is crucial for marking blocks as ticking when they're first placed.
 
 **Key Points:**
 
@@ -208,7 +208,7 @@ public class ExamplePlugin extends JavaPlugin {
 	@Override
 	protected void start() {
 		this.getChunkStoreRegistry().registerSystem(new ExampleSystem());
-		this.getChunkStoreRegistry().registerSystem(new ExampleSystemInitializer());
+		this.getChunkStoreRegistry().registerSystem(new ExampleInitializer());
 	}
 
     public ComponentType getExampleBlockComponentType() {


### PR DESCRIPTION
# Pull Request

## Description

Changed ExampleSystemInitializer to ExampleInitializer in order to match the class name with the one used

## Type of Change

- [x] Documentation fix (typo, grammar, clarification)
- [ ] New documentation (guide, tutorial, page)
- [ ] Bug fix
- [ ] New feature
- [ ] Other

## Screenshots

If applicable, add before/after screenshots:

## Checklist

- [ ] Tested locally with `bun run dev`
- [ ] Ran `bun audit` (no critical vulnerabilities)
- [x] Checked spelling and grammar
- [ ] Verified all links work
- [x] Followed [Contributing Guidelines](../CONTRIBUTING.md)

---

Thank you for contributing!
