### PR TITLE
Fix: anchor/link reference for AbstractPlayerCommand

### DIFF
--- a/content/docs/en/guides/plugin/creating-commands.mdx
+++ b/content/docs/en/guides/plugin/creating-commands.mdx
@@ -14,7 +14,7 @@ In this guide, you will learn how to create custom commands for your Hytale mod.
 You can see information on the following topics:
 - Command types
     - [AbstractAsyncCommand](#the-abstractasynccommand-class)
-    - [AbstractPlayerCommand](#the-abstracttargetplayercommand-class)
+    - [AbstractPlayerCommand](#the-abstractplayercommand-class)
     - [AbstractTargetPlayerCommand](#the-abstracttargetplayercommand-class)
     - [AbstractTargetEntityCommand](#the-abstracttargetentitycommand-class)
 - [Arguments](#adding-arguments)


### PR DESCRIPTION
# Pull Request

## Description

Fixed the anchor link for AbstractPlayerCommand.

## Type of Change

- [ ] Documentation fix (typo, grammar, clarification)
- [ ] New documentation (guide, tutorial, page)
- [ ] Bug fix
- [ ] New feature
- [X] Other

## Screenshots

If applicable, add before/after screenshots:

## Checklist

- [X] Tested locally with `bun run dev`
- [X] Ran `bun audit` (no critical vulnerabilities)
- [X] Checked spelling and grammar
- [X] Verified all links work
- [X] Followed [Contributing Guidelines](../CONTRIBUTING.md)

---

Thank you for contributing!
