### PR TITLE
fix: ECS example update

### DIFF
--- a/content/docs/en/guides/ecs/example-ecs-plugin.mdx
+++ b/content/docs/en/guides/ecs/example-ecs-plugin.mdx
@@ -233,7 +233,7 @@ public final class ExamplePlugin extends JavaPlugin {
         .registerComponent(PoisonComponent.class, PoisonComponent::new);
     PoisonComponent.setComponentType(poisonComponentType);
 
-    this.getEntityStoreRegistry().registerSystem(new PoisonSystem(this.poisonComponent));
+    this.getEntityStoreRegistry().registerSystem(new PoisonSystem(PoisonComponent.getComponentType()));
   }
 
   public static ExamplePlugin get() {


### PR DESCRIPTION
# Pull Request
Updates to ECS example to improve getComponentType and builderCodec

## Description
- Update ECS example to include the BuilderCodec to allow loading and storing components to disk to show how that can be added
- Update to ECS example to change how component type is stored. Saving component type in the component itself makes for a  more intuitive usage of calling the static method `ExampleComponent.getComponentType()` compared to the old method of needing to call `ExamplePlugin.get().getExampleComponentType()`. The old way would lead to a large number of getter methods in the plugin class if the player has a mod with a large number of components. 

Brief description of what this PR does.

## Type of Change

- [X ] Documentation fix (typo, grammar, clarification)
- [ ] New documentation (guide, tutorial, page)
- [ ] Bug fix
- [ ] New feature
- [ ] Other

## Screenshots

If applicable, add before/after screenshots:

## Checklist

- [ ] Tested locally with `bun run dev`
- [ ] Ran `bun audit` (no critical vulnerabilities)
- [ ] Checked spelling and grammar
- [ ] Verified all links work
- [ ] Followed [Contributing Guidelines](../CONTRIBUTING.md)

---

Thank you for contributing!
