### PR TITLE
GH-372: fix bad code example and rewrite the creating PermissionProvider section

### DIFF
--- a/content/docs/en/guides/plugin/permission-management.mdx
+++ b/content/docs/en/guides/plugin/permission-management.mdx
@@ -110,7 +110,7 @@ public class DatabasePermissionProvider implements PermissionProvider
 
 Then we just implement the required methods using a database implementation.
 <Callout type="warning">
-  Hytale will try to use the first available permissions provider to add/remove gamemode groups (i.e. `Creative`, `Survival`).
+  Hytale will try to use the first available permissions provider to add/remove gamemode groups (i.e. `Creative`, `Adventure`).
 
   If your provider throws an error (for instance, if the group does not exist) when the server is preparing the player, the player will be disconnected.
 </Callout>


### PR DESCRIPTION
# Pull Request

## Description

Fix #372 and rewrite the section on creating a PermissionProvider to include:
- Expanded introduction on PermissionProvider
- Detailed instructions on how Hytale handles permission providers
- Hytale handling of gamemode groups
- Disabling the default permissions provider (`HytalePermissionsProvider`)

## Type of Change

- [X] Documentation fix (typo, grammar, clarification)
- [X] New documentation (guide, tutorial, page)
- [X] Bug fix
- [ ] New feature
- [ ] Other

## Screenshots

<img width="629" height="670" alt="image" src="https://github.com/user-attachments/assets/fe502e9f-4456-4590-b2ae-3962cd05a56e" />

## Checklist

- [X] Tested locally with `bun run dev`
- [X] Ran `bun audit` (no critical vulnerabilities)
- [X] Checked spelling and grammar
- [X] Verified all links work
- [X] Followed [Contributing Guidelines](../CONTRIBUTING.md)

---

Thank you for contributing!
 gh-372
