### PR TITLE
Add note for enabling JAVA_HOME during OpenJDK setup

### DIFF
--- a/content/docs/en/guides/plugin/setting-up-env.mdx
+++ b/content/docs/en/guides/plugin/setting-up-env.mdx
@@ -25,7 +25,7 @@ Hytale modding requires Java 25 or later. We recommend using OpenJDK.
 #### Windows
 1. Download OpenJDK 25 from [Adoptium](https://adoptium.net/)
 2. Run the installer with default settings
-    - Optionally enable feature `Set or Override JAVA_HOME varaible` to resolve any build issues with your project.
+    - Optionally enable feature `Set or Override JAVA_HOME varaible` to resolve version related build issues with your project.
 3. Verify installation by opening Command Prompt and running:
 ```bash
 java -version


### PR DESCRIPTION
Added a note about enabling the JAVA_HOME variable during OpenJDK installation.

If previously installed Visual Studio with Java development turned on - JAVA_HOME will be set to an old version Microsoft uses `C:\Program Files\Microsoft\jdk-17.0.16.8-hotspot`. And this will result in build errors.

# Pull Request

## Description
I previously had Java installed via Visual Studio for some benign project. So the JAVA_HOME was set to something old that Microsoft targets for Android development. There are probably other scenarios where JAVA_HOME is set to something else. So a simple suggestion to override the path may help save a bit of troubleshooting.

Anyone who had properly learned Java and understands the setup will be fine handling this, but for people with limited Java knowledge coming from other languages etc - this would be helpful when just trying to get their foot in the door. 

For example:
```log
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.13.0:compile (default-compile) on project CommandUI: Fatal error compiling: error: invalid target release: 25 -> [Help 1]
```

## Type of Change

- [X] Documentation fix (typo, grammar, clarification)
- [ ] New documentation (guide, tutorial, page)
- [ ] Bug fix
- [ ] New feature
- [ ] Other

## Screenshots

If applicable, add before/after screenshots:

## Checklist

- [ ] Tested locally with `bun run dev`
- [ ] Ran `bun audit` (no critical vulnerabilities)
- [ ] Checked spelling and grammar
- [ ] Verified all links work
- [X] Followed [Contributing Guidelines](../CONTRIBUTING.md)

---

Thank you for contributing!
