### PR TITLE
GH-389: Fix Setter description in CODEC guide

### DIFF
--- a/content/docs/en/guides/ecs/hytale-ecs-theory.mdx
+++ b/content/docs/en/guides/ecs/hytale-ecs-theory.mdx
@@ -210,7 +210,7 @@ This might seem tedious at first but it ensures that your component can be corre
     KeyedCodec<Integer> exampleInt = new KeyedCodec<Integer>("ExampleIntIdForCodec", Codec.INTEGER);
     ```
 
-- **Setter Function**: This is a lambda function that takes an instance of your component and returns the value of the field you want to serialize. For example, if you have a field called `myCustomField` in your custom component, your getter function would look like this:
+- **Setter Function**: This is a lambda function that takes an instance of your component + the value to set and sets the field value on the component. For example, if you have a field called `myCustomField` in your custom component, your setter function would look like this:
     ```java
     (data, value) -> data.myCustomField = value
     ```


### PR DESCRIPTION
## Description

The setter description is the same as the getter description. This PR fixes this issue

## Type of Change

- [x] Documentation fix (typo, grammar, clarification)
- [ ] New documentation (guide, tutorial, page)
- [ ] Bug fix
- [ ] New feature
- [ ] Other

## Checklist

- [x] Tested locally with `bun run dev`
- [x] Ran `bun audit` (no critical vulnerabilities)
- [x] Checked spelling and grammar
- [x] Verified all links work
- [x] Followed [Contributing Guidelines](../CONTRIBUTING.md)

---
Closes #389 

Thank you for contributing!
