### PR TITLE
fix: broken hyperlink and filename typo 

### DIFF
--- a/content/docs/en/guides/plugin/store-persistent-data.mdx
+++ b/content/docs/en/guides/plugin/store-persistent-data.mdx
@@ -167,4 +167,4 @@ And that's it! Your data will now be saved and loaded automatically with the pla
 Using custom components to store persistent data on players is a powerful way to maintain state across sessions.
 By following the steps outlined above, you can easily create, register, and utilize your own data structures within the Hytale ECS framework.
 This approach ensures that your data is seamlessly integrated with the game's existing systems.
-For more information about Hytale's Entity Component System visit the [Hytale ECS Theory](https://hytalemodding.dev/en/docs/plugin/plugin/hytale-ecs-theory) guide.
+For more information about Hytale's Entity Component System visit the [Hytale ECS Theory](https://hytalemodding.dev/en/docs/guides/ecs/hytale-ecs-theory) guide.


### PR DESCRIPTION
# Pull Request

## Description

Change file name to fix typo persistant -> persistent
Fix broken hyperlink in guide

## Type of Change

- [x] Documentation fix (typo, grammar, clarification)
- [ ] New documentation (guide, tutorial, page)
- [ ] Bug fix
- [ ] New feature
- [ ] Other

## Screenshots

If applicable, add before/after screenshots:

## Checklist

- [x] Tested locally with `bun run dev`
- [x] Ran `bun audit` (no critical vulnerabilities)
- [x] Checked spelling and grammar
- [x] Verified all links work
- [x] Followed [Contributing Guidelines](../CONTRIBUTING.md)

---

Thank you for contributing!
