### PR TITLE
GH-395 feat: translation guidelines

### DIFF
--- a/content/docs/en/contributing/translate.mdx
+++ b/content/docs/en/contributing/translate.mdx
@@ -11,13 +11,13 @@ HytaleModding is translated with the help of the community using **Crowdin**. If
 
 All translations are managed **via Crowdin**.
 
-1. Visit [our Crowdin](https://translate.hytalemodding.dev/) and login if required.
+1. Visit [our Crowdin project](https://crowdin.com/project/hytalemodding) and login if required.
 2. Click on your language
-3. Click on the file/article you wish to translate
+3. Click on the file/article you wish to translate. We recommend starting with Official Documentation, and then Server Plugin Documentation.
 4. Start translating!
 5. Approved translations will appear on the website
 
-**Video guide**
+### Video Guide
 <video controls className="my-6 aspect-video w-full rounded-lg border">
   <source
     src="https://www.youtube.com/watch?v=NHiG1rDRgks"
@@ -28,27 +28,25 @@ All translations are managed **via Crowdin**.
 
 ## How to discuss
 
-You can always report issues or discuss specific topics directly on Crowdin, but we recommend to use Discord instead of the crowdin comment system to keep everything organized in one place..
+You can always report issues or discuss specific topics directly on Crowdin, but we recommend to use Discord instead of the crowdin comment system to keep everything organized in one place.
 
 1. Join [our Discord](https://discord.gg/hytalemodding)
-2. Open `#translation` channel. Here you can discuss or ask quesions which aren't specific for specific language.
-3. If you want to join thread you are required to run `/translator <your-language>` command here. Bot will join you to thread of your language. If you can't see your language:
-  - It could be not available on Crowdin. Then you may request it.
-  - If you see it on Crowdin then it's missing in our bot. You may ping **Neil** and tell it.
+2. Open `#translations` channel. Here you can discuss or ask questions which don't relate for specific language.
+3. If you want to join thread you are required to run `/translator <your-language>` command here. Bot will join you to thread of your language.
 
 ## Translation Guidelines
 
 - You need to be confident in what you are translating, you should be able to read the text you just translated and understand the meaning of it very easily.
-- It should use the most simplest form of language possible. Use english words if the translation is unknown to the majority in your country.
-- Use your imagination, trust yourself. Feel free to change any context as you wish as long as it still means the same thing and is understandable.
+- It should use the simplest form of language possible. Use English words if the translation is unknown to the majority in your country.
+- Use your imagination, trust yourself. Feel free to change any context as you wish as long as it can still get the same point across and is understandable.
 - These guidelines are always more important than language specific, but lower than Hytale's.
 
-### What no to translate
+### What not to translate
 
 We request you all to not translate these specific sections of the website:
 
-**Callout types**
-Callouts are the boxes that contain important information. We request you to not translate the types as they only work in the english language. 
+### Callout types
+Callouts are the boxes that contain important information. We request you to not translate the types as they only work in the English. 
 
 **Example:**
 ```mdx
@@ -59,8 +57,8 @@ Translate the text in between!
 
 In this example, please don't translate the word warning, the rest you can translate.
 
-**Icons**
-Icon names must be not translated.
+###Icons
+Icon names must not be translated.
 They are technical identifiers and are mapped directly to existing icons. Translating them will break the icon rendering.
 ```mdx
 icon: Globe
@@ -70,7 +68,7 @@ icon: Globe
 {/* 
 For translators who will edit this page:
 
--You are required to translate Guidelines as they change.
+-You are required to translate the Guidelines as they change.
 -General guidelines should be translated but not edited.
 -Learn how to use Markdown from writing_guides.mdx
 */}


### PR DESCRIPTION
# Pull Request

## Description

In this PR, I added a Translation guidelines page for easier access and familiarization with the HytaleModing translation guidelines, both general and language-specific. I used pinned messages from Discord to fill them in.

I didn't check it due to problems with nextjs.

I didn't add it to other languages ​​because you can change something before that. If everything is fine, I would advise you to ping the translators for review and editing.

## Type of Change

- [ ] Documentation fix (typo, grammar, clarification)
- [x] New documentation (guide, tutorial, page)
- [ ] Bug fix
- [ ] New feature
- [ ] Other


## Checklist

- [ ] Tested locally with `bun run dev`
- [ ] Ran `bun audit` (no critical vulnerabilities)
- [x] Checked spelling and grammar
- [x] Verified all links work
- [x] Followed [Contributing Guidelines](../CONTRIBUTING.md)

--- gh-395
