### PR TITLE
GH-385: add logo on the navbar title

### DIFF
--- a/src/lib/layout.shared.tsx
+++ b/src/lib/layout.shared.tsx
@@ -1,6 +1,8 @@
+import Image from "next/image";
 import { BookIcon } from "lucide-react";
 import type { BaseLayoutProps } from "fumadocs-ui/layouts/shared";
 import { i18n } from "@/lib/i18n";
+import HytaleModdingLogo from "@/app/icon0.svg";
 import { getMessages } from "./locale";
 
 export function baseOptions(
@@ -12,7 +14,14 @@ export function baseOptions(
   let options: BaseLayoutProps = {
     i18n,
     nav: {
-      title: messages.nav.title,
+      title: (
+        <>
+          <div className="relative h-12 w-12 lg:h-8 lg:w-8">
+            <Image alt="Hytale Modding" src={HytaleModdingLogo} fill />
+          </div>
+          <span className="font-medium">{messages.nav.title}</span>
+        </>
+      ),
       url: `/${locale}/`,
     },
   };


### PR DESCRIPTION
# Pull Request

## Description

Adds HytaleModding's logo on the navbar.

## Type of Change

- [ ] Documentation fix (typo, grammar, clarification)
- [ ] New documentation (guide, tutorial, page)
- [ ] Bug fix
- [x] New feature
- [ ] Other

## Screenshots

Before (`/en`)
<img width="1497" height="713" alt="image" src="https://github.com/user-attachments/assets/3b4db70b-80ce-47d3-80a7-b57e55ad3480" />

After (`/en`)
<img width="1497" height="713" alt="image" src="https://github.com/user-attachments/assets/63f26635-b87d-403a-ad04-c07f80d54822" />

Before (mobile, `/en/docs`)
<img width="371" height="517" alt="image" src="https://github.com/user-attachments/assets/dc390fc7-e0df-43c5-bd28-1b6ba7a57fda" />

After (mobile, `/en/docs`)
<img width="371" height="501" alt="image" src="https://github.com/user-attachments/assets/6bd36d34-1d84-4554-b22f-2c02c09df959" />

## Checklist

- [x] Tested locally with `bun run dev`
- [ ] ~Ran `bun audit` (no critical vulnerabilities)~ This script doesn't exist on `package.json`
- [x] Checked spelling and grammar
- [x] Verified all links work
- [x] Followed [Contributing Guidelines](../CONTRIBUTING.md)

---
closes #385 

Thank you for reviewing!