### PR TITLE
GH-412: Add information about using Common.ui from subfolders

### DIFF
--- a/content/docs/en/official-documentation/custom-ui/common-styling.mdx
+++ b/content/docs/en/official-documentation/custom-ui/common-styling.mdx
@@ -8,7 +8,7 @@ title: "Common Styling"
 
 This document describes the shared UI components and styles defined in `Common.ui`.
 
-***
+---
 
 ### Styles
 
@@ -17,7 +17,7 @@ We are providing some styles that can be re-used in any custom UI that, provide 
 You can find a list of all the styles defined with live examples by running the `/ui-gallery` command ingame.
 
 <Callout type="warning">
-This command is not available yet, but will be in a future patch.
+  This command is not available yet, but will be in a future patch.
 </Callout>
 
 ![Gallery](/assets/official-documentation/ui/gallery.png)
@@ -34,3 +34,13 @@ $Common.@TextButton { @Text = "My Button"; }
 $Common.@Container { ... }
 ```
 
+<Callout type="info">
+The `Common.ui` file is at `Common/UI/Custom/Common.ui` within the Hytale pack. If your custom ui document is in a subfolder of `Common/UI/Custom/`, reference it via relative path traversal:
+
+```
+$Common = "../Common.ui";
+```
+
+You can find more info about paths [here](markup#path).
+
+</Callout>


### PR DESCRIPTION
# Pull Request

## Description

Adds an information box about how to reference the `Common.ui` file from a ui document that is in a subfolder.

## Type of Change

- [x] Documentation fix (typo, grammar, clarification)
- [ ] New documentation (guide, tutorial, page)
- [ ] Bug fix
- [ ] New feature
- [ ] Other

## Screenshots

<img width="922" height="626" alt="2026-02-06T12-26-13" src="https://github.com/user-attachments/assets/37ed4495-c37f-4488-b89a-a7962ab2adab" />

## Checklist

- [x] Tested locally with `bun run dev`
- [x] Ran `bun audit` (no critical vulnerabilities)
- [x] Checked spelling and grammar
- [x] Verified all links work
- [x] Followed [Contributing Guidelines](../CONTRIBUTING.md)

---

Thank you for contributing!
 gh-412
