### PR TITLE
GH-451 fix(docs): correct ProjectileHit typo in interaction reference

### DIFF
--- a/content/docs/en/server/interaction-reference.mdx
+++ b/content/docs/en/server/interaction-reference.mdx
@@ -77,7 +77,7 @@ All interactions of every type below are inherited from Interaction and have the
 - `Death`
 - `Wielding`
 - `ProjectileSpawn`
-- `ProjectilHit`
+- `ProjectileHit`
 - `ProjectileMiss`
 - `ProjectileBounce`
 - `Held`
@@ -215,7 +215,7 @@ This interaction can be used to cancel one or more running interaction chains on
 - `Death`
 - `Wielding`
 - `ProjectileSpawn`
-- `ProjectilHit`
+- `ProjectileHit`
 - `ProjectileMiss`
 - `ProjectileBounce`
 - `Held`
@@ -644,7 +644,7 @@ One pitfall to be careful of when setting `AllowIndefiniteHold` to false is the 
 - `Death`
 - `Wielding`
 - `ProjectileSpawn`
-- `ProjectilHit`
+- `ProjectileHit`
 - `ProjectileMiss`
 - `ProjectileBounce`
 - `Held`


### PR DESCRIPTION
## Summary
- fixed typo `ProjectilHit` -> `ProjectileHit` in the three InteractionType lists on `/docs/server/interaction-reference`
- no unrelated content changed

## Validation
- verified all three occurrences in `content/docs/en/server/interaction-reference.mdx` are corrected
- `grep -n "ProjectilHit" content/docs/en/server/interaction-reference.mdx` returns no matches

Closes #451