### PR TITLE
fix: convert style string to object as react expects it

### DIFF
--- a/content/docs/en/official-documentation/worldgen/worldgen-tutorial/README.mdx
+++ b/content/docs/en/official-documentation/worldgen/worldgen-tutorial/README.mdx
@@ -62,9 +62,13 @@ https://drive.google.com/file/d/1BJurxyj-taE-PXWm04bk7Dl6X7ZHTH92/view?usp=shari
 #### Requirements
 
 * You must be an **Operator** in the world.
-  * To do this, run <mark style="color:$danger;">`/op self`</mark>
+  * To do this, run <mark style={{
+    color: "var(--destructive)"
+  }}>`/op self`</mark>
 * You must be in **Creative mode**.
-  * Press the <mark style="color:$danger;">`O`</mark> key, O for Orange.&#x20;
+  * Press the <mark style={{
+    color: "var(--destructive)"
+  }}>`O`</mark> key, O for Orange.&#x20;
 
 The generation assets define a set of generators but on their own you cannot visit these. Currently you require an Instance with a generator that will allow you to visit your work.
 


### PR DESCRIPTION
# Pull Request

## Description

Converts the style string `"color:$danger;"` to
```ts
{{
    color: "var(--destructive)"
  }}
```
as that's how React expects it.

This fixes the root cause of why site was not building.


## Type of Change

- [ ] Documentation fix (typo, grammar, clarification)
- [ ] New documentation (guide, tutorial, page)
- [x] Bug fix
- [ ] New feature
- [ ] Other

## Screenshots

If applicable, add before/after screenshots:

## Checklist

- [x] Tested locally with `bun run dev`
- [ ] Formatted code to adhere Styleguide with `bun format`
- [x] Ran `bun audit` (no critical vulnerabilities)
- [x] Checked spelling and grammar
- [x] Verified all links work
- [x] Followed [Contributing Guidelines](../CONTRIBUTING.md)

---

Thank you for contributing!
