### PR TITLE
feat: Add UI translation info

### DIFF
--- a/content/docs/en/guides/plugin/ui.mdx
+++ b/content/docs/en/guides/plugin/ui.mdx
@@ -232,6 +232,18 @@ public void updateText(String newText) {
 }
 ```
 
+## Localizing Values (Translating item object names)
+In some cases you will want to display the name of something you have the itemStack of or something in game.
+You can use the following to display the localized name:
+```java
+ItemStack heldItemStack = player.getInventory().getActiveHotbarItem();
+
+String itemId = heldItemStack.getItem.getId();
+String translationKey = Item.getAssetMap().getAsset(itemId).getTranslationKey();
+Message msg = Message.translation(translationKey);
+uiCommandBuilder.set("#MyButton.Text", msg);
+```
+
 ## Common Issues
 
 ### Failed to apply Custom UI HUD commands


### PR DESCRIPTION
# Pull Request

## Description

Add section to UI documentation on how to get a localized item name to be displayed on the UI. Most example show how to statically define values but example allows the player to pass in an ItemStack to the UI and get the correctly translated name.

## Type of Change

- [X] Documentation fix (typo, grammar, clarification)
- [ ] New documentation (guide, tutorial, page)
- [ ] Bug fix
- [ ] New feature
- [ ] Other

## Screenshots

If applicable, add before/after screenshots:

## Checklist

- [ ] Tested locally with `bun run dev`
- [ ] Formatted code to adhere Styleguide with `bun format`
- [ ] Ran `bun audit` (no critical vulnerabilities)
- [ ] Checked spelling and grammar
- [ ] Verified all links work
- [ ] Followed [Contributing Guidelines](../CONTRIBUTING.md)

---

Thank you for contributing!
