### PR TITLE
docs: added xpLimit to gainExperience(int value)

### DIFF
--- a/content/docs/af-ZA/guides/java-basics/13-inheritance.mdx
+++ b/content/docs/af-ZA/guides/java-basics/13-inheritance.mdx
@@ -294,11 +294,14 @@ public class Player extends Entity {
     }
     
     public void gainExperience(int amount) {
+        int xpLimit = level * 100;
         experience += amount;
         System.out.println("Gained " + amount + " XP");
-        
-        if (experience >= level * 100) {
+
+        while (experience >= xpLimit) {
+            experience -= xpLimit;
             levelUp();
+            xpLimit = level * 100;
         }
     }
     

--- a/content/docs/ar-SA/guides/java-basics/13-inheritance.mdx
+++ b/content/docs/ar-SA/guides/java-basics/13-inheritance.mdx
@@ -294,11 +294,14 @@ public class Player extends Entity {
     }
     
     public void gainExperience(int amount) {
+        int xpLimit = level * 100;
         experience += amount;
         System.out.println("Gained " + amount + " XP");
-        
-        if (experience >= level * 100) {
+
+        while (experience >= xpLimit) {
+            experience -= xpLimit;
             levelUp();
+            xpLimit = level * 100;
         }
     }
     

--- a/content/docs/cs-CZ/guides/java-basics/13-inheritance.mdx
+++ b/content/docs/cs-CZ/guides/java-basics/13-inheritance.mdx
@@ -294,11 +294,14 @@ public class Player extends Entity {
     }
     
     public void gainExperience(int amount) {
+        int xpLimit = level * 100;
         experience += amount;
         System.out.println("Gained " + amount + " XP");
-        
-        if (experience >= level * 100) {
+
+        while (experience >= xpLimit) {
+            experience -= xpLimit;
             levelUp();
+            xpLimit = level * 100;
         }
     }
     

--- a/content/docs/da-DK/guides/java-basics/13-inheritance.mdx
+++ b/content/docs/da-DK/guides/java-basics/13-inheritance.mdx
@@ -294,11 +294,14 @@ public class Player extends Entity {
     }
     
     public void gainExperience(int amount) {
+        int xpLimit = level * 100;
         experience += amount;
         System.out.println("Gained " + amount + " XP");
-        
-        if (experience >= level * 100) {
+
+        while (experience >= xpLimit) {
+            experience -= xpLimit;
             levelUp();
+            xpLimit = level * 100;
         }
     }
     

--- a/content/docs/de-DE/guides/java-basics/13-inheritance.mdx
+++ b/content/docs/de-DE/guides/java-basics/13-inheritance.mdx
@@ -294,11 +294,14 @@ public class Player extends Entity {
     }
     
     public void gainExperience(int amount) {
+        int xpLimit = level * 100;
         experience += amount;
         System.out.println("Gained " + amount + " XP");
-        
-        if (experience >= level * 100) {
+
+        while (experience >= xpLimit) {
+            experience -= xpLimit;
             levelUp();
+            xpLimit = level * 100;
         }
     }
     

--- a/content/docs/en/guides/java-basics/13-inheritance.mdx
+++ b/content/docs/en/guides/java-basics/13-inheritance.mdx
@@ -290,11 +290,14 @@ public class Player extends Entity {
     }
     
     public void gainExperience(int amount) {
+        int xpLimit = level * 100;
         experience += amount;
         System.out.println("Gained " + amount + " XP");
-        
-        if (experience >= level * 100) {
+
+        while (experience >= xpLimit) {
+            experience -= xpLimit;
             levelUp();
+            xpLimit = level * 100;
         }
     }
     

--- a/content/docs/es-ES/guides/java-basics/13-inheritance.mdx
+++ b/content/docs/es-ES/guides/java-basics/13-inheritance.mdx
@@ -294,11 +294,14 @@ public class Player extends Entity {
     }
     
     public void gainExperience(int amount) {
+        int xpLimit = level * 100;
         experience += amount;
         System.out.println("Gained " + amount + " XP");
-        
-        if (experience >= level * 100) {
+
+        while (experience >= xpLimit) {
+            experience -= xpLimit;
             levelUp();
+            xpLimit = level * 100;
         }
     }
     

--- a/content/docs/fr-FR/guides/java-basics/13-inheritance.mdx
+++ b/content/docs/fr-FR/guides/java-basics/13-inheritance.mdx
@@ -294,11 +294,14 @@ public class Player extends Entity {
     }
     
     public void gainExperience(int amount) {
+        int xpLimit = level * 100;
         experience += amount;
         System.out.println("Gained " + amount + " XP");
-        
-        if (experience >= level * 100) {
+
+        while (experience >= xpLimit) {
+            experience -= xpLimit;
             levelUp();
+            xpLimit = level * 100;
         }
     }
     

--- a/content/docs/hi-IN/guides/java-basics/13-inheritance.mdx
+++ b/content/docs/hi-IN/guides/java-basics/13-inheritance.mdx
@@ -294,11 +294,14 @@ public class Player extends Entity {
     }
     
     public void gainExperience(int amount) {
+        int xpLimit = level * 100;
         experience += amount;
         System.out.println("Gained " + amount + " XP");
-        
-        if (experience >= level * 100) {
+
+        while (experience >= xpLimit) {
+            experience -= xpLimit;
             levelUp();
+            xpLimit = level * 100;
         }
     }
     

--- a/content/docs/hu-HU/guides/java-basics/13-inheritance.mdx
+++ b/content/docs/hu-HU/guides/java-basics/13-inheritance.mdx
@@ -294,11 +294,14 @@ public class Player extends Entity {
     }
     
     public void gainExperience(int amount) {
+        int xpLimit = level * 100;
         experience += amount;
         System.out.println("Gained " + amount + " XP");
-        
-        if (experience >= level * 100) {
+
+        while (experience >= xpLimit) {
+            experience -= xpLimit;
             levelUp();
+            xpLimit = level * 100;
         }
     }
     

--- a/content/docs/id-ID/guides/java-basics/13-inheritance.mdx
+++ b/content/docs/id-ID/guides/java-basics/13-inheritance.mdx
@@ -294,11 +294,14 @@ public class Player extends Entity {
     }
     
     public void gainExperience(int amount) {
+        int xpLimit = level * 100;
         experience += amount;
         System.out.println("Gained " + amount + " XP");
-        
-        if (experience >= level * 100) {
+
+        while (experience >= xpLimit) {
+            experience -= xpLimit;
             levelUp();
+            xpLimit = level * 100;
         }
     }
     

--- a/content/docs/it-IT/guides/java-basics/13-inheritance.mdx
+++ b/content/docs/it-IT/guides/java-basics/13-inheritance.mdx
@@ -294,11 +294,14 @@ public class Player extends Entity {
     }
     
     public void gainExperience(int amount) {
+        int xpLimit = level * 100;
         experience += amount;
-        System.out.println("Hai guadagnato " + amount + " XP");
-        
-        if (experience >= level * 100) {
+        System.out.println("Gained " + amount + " XP");
+
+        while (experience >= xpLimit) {
+            experience -= xpLimit;
             levelUp();
+            xpLimit = level * 100;
         }
     }
     

--- a/content/docs/it-IT/guides/java-basics/13-inheritance.mdx
+++ b/content/docs/it-IT/guides/java-basics/13-inheritance.mdx
@@ -296,7 +296,7 @@ public class Player extends Entity {
     public void gainExperience(int amount) {
         int xpLimit = level * 100;
         experience += amount;
-        System.out.println("Gained " + amount + " XP");
+        System.out.println("Hai guadagnato " + amount + " XP");
 
         while (experience >= xpLimit) {
             experience -= xpLimit;

--- a/content/docs/ja-JP/guides/java-basics/13-inheritance.mdx
+++ b/content/docs/ja-JP/guides/java-basics/13-inheritance.mdx
@@ -294,11 +294,14 @@ public class Player extends Entity {
     }
     
     public void gainExperience(int amount) {
+        int xpLimit = level * 100;
         experience += amount;
         System.out.println("Gained " + amount + " XP");
-        
-        if (experience >= level * 100) {
+
+        while (experience >= xpLimit) {
+            experience -= xpLimit;
             levelUp();
+            xpLimit = level * 100;
         }
     }
     

--- a/content/docs/lt-LT/guides/java-basics/13-inheritance.mdx
+++ b/content/docs/lt-LT/guides/java-basics/13-inheritance.mdx
@@ -294,11 +294,14 @@ public class Player extends Entity {
     }
     
     public void gainExperience(int amount) {
+        int xpLimit = level * 100;
         experience += amount;
         System.out.println("Gained " + amount + " XP");
-        
-        if (experience >= level * 100) {
+
+        while (experience >= xpLimit) {
+            experience -= xpLimit;
             levelUp();
+            xpLimit = level * 100;
         }
     }
     

--- a/content/docs/lv-LV/guides/java-basics/13-inheritance.mdx
+++ b/content/docs/lv-LV/guides/java-basics/13-inheritance.mdx
@@ -294,11 +294,14 @@ public class Player extends Entity {
     }
     
     public void gainExperience(int amount) {
+        int xpLimit = level * 100;
         experience += amount;
         System.out.println("Gained " + amount + " XP");
-        
-        if (experience >= level * 100) {
+
+        while (experience >= xpLimit) {
+            experience -= xpLimit;
             levelUp();
+            xpLimit = level * 100;
         }
     }
     

--- a/content/docs/nl-NL/guides/java-basics/13-inheritance.mdx
+++ b/content/docs/nl-NL/guides/java-basics/13-inheritance.mdx
@@ -294,11 +294,14 @@ public class Player extends Entity {
     }
     
     public void gainExperience(int amount) {
+        int xpLimit = level * 100;
         experience += amount;
         System.out.println("Gained " + amount + " XP");
-        
-        if (experience >= level * 100) {
+
+        while (experience >= xpLimit) {
+            experience -= xpLimit;
             levelUp();
+            xpLimit = level * 100;
         }
     }
     

--- a/content/docs/pl-PL/guides/java-basics/13-inheritance.mdx
+++ b/content/docs/pl-PL/guides/java-basics/13-inheritance.mdx
@@ -294,11 +294,14 @@ public class Player extends Entity {
     }
     
     public void gainExperience(int amount) {
+        int xpLimit = level * 100;
         experience += amount;
         System.out.println("Gained " + amount + " XP");
-        
-        if (experience >= level * 100) {
+
+        while (experience >= xpLimit) {
+            experience -= xpLimit;
             levelUp();
+            xpLimit = level * 100;
         }
     }
     

--- a/content/docs/pt-BR/guides/java-basics/13-inheritance.mdx
+++ b/content/docs/pt-BR/guides/java-basics/13-inheritance.mdx
@@ -294,11 +294,14 @@ public class Player extends Entity {
     }
     
     public void gainExperience(int amount) {
+        int xpLimit = level * 100;
         experience += amount;
-        System.out.println("+" + amount + " de XP obtida");
-        
-        if (experience >= level * 100) {
+        System.out.println("Gained " + amount + " XP");
+
+        while (experience >= xpLimit) {
+            experience -= xpLimit;
             levelUp();
+            xpLimit = level * 100;
         }
     }
     

--- a/content/docs/pt-BR/guides/java-basics/13-inheritance.mdx
+++ b/content/docs/pt-BR/guides/java-basics/13-inheritance.mdx
@@ -296,7 +296,7 @@ public class Player extends Entity {
     public void gainExperience(int amount) {
         int xpLimit = level * 100;
         experience += amount;
-        System.out.println("Gained " + amount + " XP");
+        System.out.println("+" + amount + " de XP obtida");
 
         while (experience >= xpLimit) {
             experience -= xpLimit;

--- a/content/docs/pt-PT/guides/java-basics/13-inheritance.mdx
+++ b/content/docs/pt-PT/guides/java-basics/13-inheritance.mdx
@@ -294,11 +294,14 @@ public class Player extends Entity {
     }
     
     public void gainExperience(int amount) {
+        int xpLimit = level * 100;
         experience += amount;
         System.out.println("Gained " + amount + " XP");
-        
-        if (experience >= level * 100) {
+
+        while (experience >= xpLimit) {
+            experience -= xpLimit;
             levelUp();
+            xpLimit = level * 100;
         }
     }
     

--- a/content/docs/ro-RO/guides/java-basics/13-inheritance.mdx
+++ b/content/docs/ro-RO/guides/java-basics/13-inheritance.mdx
@@ -294,11 +294,14 @@ public class Player extends Entity {
     }
     
     public void gainExperience(int amount) {
+        int xpLimit = level * 100;
         experience += amount;
         System.out.println("Gained " + amount + " XP");
-        
-        if (experience >= level * 100) {
+
+        while (experience >= xpLimit) {
+            experience -= xpLimit;
             levelUp();
+            xpLimit = level * 100;
         }
     }
     

--- a/content/docs/ru-RU/guides/java-basics/13-inheritance.mdx
+++ b/content/docs/ru-RU/guides/java-basics/13-inheritance.mdx
@@ -294,11 +294,14 @@ public class Player extends Entity {
     }
     
     public void gainExperience(int amount) {
+        int xpLimit = level * 100;
         experience += amount;
         System.out.println("Gained " + amount + " XP");
-        
-        if (experience >= level * 100) {
+
+        while (experience >= xpLimit) {
+            experience -= xpLimit;
             levelUp();
+            xpLimit = level * 100;
         }
     }
     

--- a/content/docs/sq-AL/guides/java-basics/13-inheritance.mdx
+++ b/content/docs/sq-AL/guides/java-basics/13-inheritance.mdx
@@ -294,11 +294,14 @@ public class Player extends Entity {
     }
     
     public void gainExperience(int amount) {
+        int xpLimit = level * 100;
         experience += amount;
         System.out.println("Gained " + amount + " XP");
-        
-        if (experience >= level * 100) {
+
+        while (experience >= xpLimit) {
+            experience -= xpLimit;
             levelUp();
+            xpLimit = level * 100;
         }
     }
     

--- a/content/docs/sv-SE/guides/java-basics/13-inheritance.mdx
+++ b/content/docs/sv-SE/guides/java-basics/13-inheritance.mdx
@@ -294,11 +294,14 @@ public class Player extends Entity {
     }
     
     public void gainExperience(int amount) {
+        int xpLimit = level * 100;
         experience += amount;
         System.out.println("Gained " + amount + " XP");
-        
-        if (experience >= level * 100) {
+
+        while (experience >= xpLimit) {
+            experience -= xpLimit;
             levelUp();
+            xpLimit = level * 100;
         }
     }
     

--- a/content/docs/tr-TR/guides/java-basics/13-inheritance.mdx
+++ b/content/docs/tr-TR/guides/java-basics/13-inheritance.mdx
@@ -294,11 +294,14 @@ public class Player extends Entity {
     }
     
     public void gainExperience(int amount) {
+        int xpLimit = level * 100;
         experience += amount;
         System.out.println("Gained " + amount + " XP");
-        
-        if (experience >= level * 100) {
+
+        while (experience >= xpLimit) {
+            experience -= xpLimit;
             levelUp();
+            xpLimit = level * 100;
         }
     }
     

--- a/content/docs/uk-UA/guides/java-basics/13-inheritance.mdx
+++ b/content/docs/uk-UA/guides/java-basics/13-inheritance.mdx
@@ -14,7 +14,7 @@ Think of inheritance like a family tree. A child inherits traits from their pare
 public class Entity {
     protected String name;
     protected int health;
-    
+
     public Entity(String name, int health) {
         this.name = name;
         this.health = health;
@@ -294,11 +294,14 @@ public class Player extends Entity {
     }
     
     public void gainExperience(int amount) {
+        int xpLimit = level * 100;
         experience += amount;
         System.out.println("Gained " + amount + " XP");
-        
-        if (experience >= level * 100) {
+
+        while (experience >= xpLimit) {
+            experience -= xpLimit;
             levelUp();
+            xpLimit = level * 100;
         }
     }
     

--- a/content/docs/uk-UA/guides/java-basics/13-inheritance.mdx
+++ b/content/docs/uk-UA/guides/java-basics/13-inheritance.mdx
@@ -14,7 +14,7 @@ Think of inheritance like a family tree. A child inherits traits from their pare
 public class Entity {
     protected String name;
     protected int health;
-
+    
     public Entity(String name, int health) {
         this.name = name;
         this.health = health;

--- a/content/docs/vi-VN/guides/java-basics/13-inheritance.mdx
+++ b/content/docs/vi-VN/guides/java-basics/13-inheritance.mdx
@@ -294,11 +294,14 @@ public class Player extends Entity {
     }
     
     public void gainExperience(int amount) {
+        int xpLimit = level * 100;
         experience += amount;
         System.out.println("Gained " + amount + " XP");
-        
-        if (experience >= level * 100) {
+
+        while (experience >= xpLimit) {
+            experience -= xpLimit;
             levelUp();
+            xpLimit = level * 100;
         }
     }
     


### PR DESCRIPTION
# Pull Request

## Description

I added xpLimit variable to the gainExperience method to fix the problem of xp overflow, that occurs when levelUp() method is called

## Type of Change

- [x] Documentation fix (typo, grammar, clarification)
- [ ] New documentation (guide, tutorial, page)
- [ ] Bug fix
- [ ] New feature
- [ ] Other

## Screenshots
Before:
<img width="850" height="644" alt="Снимок экрана 2026-03-23 в 16 45 00" src="https://github.com/user-attachments/assets/8116dd20-298e-4452-9e2b-c316eee1db51" />

After:
<img width="850" height="644" alt="Снимок экрана 2026-03-23 в 16 44 06" src="https://github.com/user-attachments/assets/a2cc3635-9167-4752-bb61-0e08da59bad1" />


## Checklist

- [x] Tested locally with `bun run dev`
- [x] Formatted code to adhere Styleguide with `bun format`
- [x] Ran `bun audit` (some critical vulnerabilities but not from me)
- [x] Checked spelling and grammar
- [x] Verified all links work
- [x] Followed [Contributing Guidelines](../CONTRIBUTING.md)

---

Thank you for contributing!
