### PR TITLE
[BugFix + Tweak]: A fix and a Tag Addition

### DIFF
--- a/content/docs/en/guides/debugging-basics/intro-to-debugging.mdx
+++ b/content/docs/en/guides/debugging-basics/intro-to-debugging.mdx
@@ -10,7 +10,7 @@ This guide will go over the general process of debugging, teaching you how to ge
 
 Debugging is, put simply, the process of figuring out why your mod isn't doing what you want it to do. In this guide, I'm going to walk you through the process I use to fix my mod problems when I can't find the answer online. You're not always going to have the answers, documentation, or proper tools to instantly understand what is causing your mod to malfunction, and depending on how innovative your mod is, you might be the first person to ever need the answer. That can sound intimidating, which is exactly why this guide is here to help. These intimidating moments and how you handle them are what make the difference between someone who writes code and someone who makes mods.
 
-![Debugging](/assets/guides/debugging-basics/debugging.png)
+![Debugging](/assets/guides/debugging-basics/debugging-cycle.png)
 
 The debugging process is a cycle, as shown above, and we'll be going over each of the four steps:
 

--- a/content/docs/en/publishing/thunderstore/index.mdx
+++ b/content/docs/en/publishing/thunderstore/index.mdx
@@ -65,6 +65,7 @@ The following is a comprehensive list of Tags used by the Thunderstore Community
 * Libraries: Marks the content as a Library which includes it within the Other section, if not tied to any prior content types.
 * Combos: Marks the content as a Combo which includes it within the Combos section, think of this as bundling content types together such as a universe with a Mod.
 * Misc: Marks the content as a Miscellaneous item which includes it within the Other section, if not tied to any prior content types.
+* AI-Generated: Marks the content as AI-Generated Content, either in code, art, music, or any other form. It is required if any of the afforementioned is the case for the given Package.
 
 Note this may change over time check back on this page every once in a while or if you see a new Tag appear in the Thunderstore uploads.
 


### PR DESCRIPTION
# [BugFix + Tweak]: A fix and a Tag Addition

## Description

* Fixes the Image link for the `intro-to-debugging.mdx` article, and adds the `AI-Generated` tag to the `index.mdx` of the Thunderstore section.

## Type of Change

- [x] Documentation fix (typo, grammar, clarification)
- [ ] New documentation (guide, tutorial, page)
- [x] Bug fix
- [ ] New feature
- [ ] Other

## Screenshots

If applicable, add before/after screenshots:

## Checklist

- [x] Tested locally with `bun run dev`
- [ ] Formatted code to adhere Styleguide with `bun format` (advised not to run)
- [x] Ran `bun audit` (no critical vulnerabilities)
- [x] Checked spelling and grammar
- [x] Verified all links work
- [x] Followed [Contributing Guidelines](../CONTRIBUTING.md)

---

Thank you for contributing!