### PR TITLE
Improve Responsiveness of Homepage Redesign

### DIFF
--- a/src/app/[lang]/(home)/community.tsx
+++ b/src/app/[lang]/(home)/community.tsx
@@ -3,7 +3,6 @@
 import { TextLink } from "@/components/text-link";
 import { DiscordButton } from "@/components/discord-button";
 import Image from "next/image";
-import { Heart, MessageCircle, Send, Bookmark } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import FeranImage from "@/../public/assets/landing/hero/feran.png";
@@ -16,7 +15,6 @@ type SidePhoto = {
   rotate: number;
   side: "left" | "right";
   size?: number;
-  user?: string;
 };
 
 const PHOTOS: SidePhoto[] = [
@@ -27,7 +25,6 @@ const PHOTOS: SidePhoto[] = [
     rotate: -8,
     side: "left",
     size: 340,
-    user: "hytalemodding",
   },
   {
     src: "/assets/landing/hero/photo6.png",
@@ -36,7 +33,6 @@ const PHOTOS: SidePhoto[] = [
     rotate: 10,
     side: "left",
     size: 340,
-    user: "modjam",
   },
   {
     src: "/assets/landing/hero/photo5.png",
@@ -45,7 +41,6 @@ const PHOTOS: SidePhoto[] = [
     rotate: -10,
     side: "left",
     size: 340,
-    user: "worldsmiths",
   },
   {
     src: "/assets/landing/hero/photo4.png",
@@ -54,7 +49,6 @@ const PHOTOS: SidePhoto[] = [
     rotate: 9,
     side: "left",
     size: 340,
-    user: "creators",
   },
   {
     src: "/assets/landing/hero/photo3.png",
@@ -63,7 +57,6 @@ const PHOTOS: SidePhoto[] = [
     rotate: 10,
     side: "right",
     size: 340,
-    user: "townhall",
   },
   {
     src: "/assets/landing/hero/photo8.png",
@@ -72,7 +65,6 @@ const PHOTOS: SidePhoto[] = [
     rotate: -10,
     side: "right",
     size: 340,
-    user: "buildclub",
   },
   {
     src: "/assets/landing/hero/photo7.png",
@@ -81,7 +73,6 @@ const PHOTOS: SidePhoto[] = [
     rotate: 8,
     side: "right",
     size: 340,
-    user: "artistry",
   },
   {
     src: "/assets/landing/hero/photo1.png",
@@ -90,7 +81,6 @@ const PHOTOS: SidePhoto[] = [
     rotate: -10,
     side: "right",
     size: 340,
-    user: "community",
   },
 ];
 
@@ -144,269 +134,30 @@ function Polaroid({
           pointerEvents: "none",
         }}
       >
-        <InstagramCard
-          photo={photo}
-          size={size}
-          onOpen={onOpen}
-          hovered={hovered}
-          rotate={photo.rotate}
-        />
-      </div>
-    </div>
-  );
-}
-
-function InstagramCard({
-  photo,
-  size,
-  onOpen,
-  hovered = false,
-  rotate = 0,
-  fill = false,
-}: {
-  photo: SidePhoto;
-  size: number;
-  onOpen: (src: string) => void;
-  hovered?: boolean;
-  rotate?: number;
-  fill?: boolean;
-}) {
-  return (
-    <div
-      style={{
-        transform: rotate ? `rotate(${rotate}deg)` : undefined,
-        background: "#fff",
-        borderRadius: 12,
-        overflow: "hidden",
-        border: "1px solid rgba(0,0,0,0.08)",
-        height: fill ? "100%" : undefined,
-        display: fill ? "flex" : undefined,
-        flexDirection: fill ? "column" : undefined,
-        boxShadow: hovered
-          ? "0 16px 30px rgba(0,0,0,0.30)"
-          : "0 5px 16px rgba(0,0,0,0.20)",
-        pointerEvents: "auto",
-        cursor: "pointer",
-        transition: "box-shadow 0.3s ease",
-        color: "#0f172a",
-      }}
-    >
-      {/* header */}
-      <div
-        style={{
-          display: "flex",
-          alignItems: "center",
-          gap: 8,
-          padding: "8px 10px",
-        }}
-      >
         <div
+          onClick={() => onOpen(photo.src)}
           style={{
-            width: 26,
-            height: 26,
-            borderRadius: "50%",
-            padding: 2,
-            background:
-              "linear-gradient(45deg,#f09433,#e6683c,#dc2743,#cc2366,#bc1888)",
-            flexShrink: 0,
+            transform: `rotate(${photo.rotate}deg)`,
+            border: "4px solid var(--paper, #fff)",
+            borderRadius: 10,
+            overflow: "hidden",
+            boxShadow: hovered
+              ? "0 14px 26px rgba(0,0,0,0.28)"
+              : "0 4px 14px rgba(0,0,0,0.18)",
+            pointerEvents: "auto",
+            cursor: "pointer",
+            transition: "box-shadow 0.3s ease",
           }}
         >
-          <div
-            style={{
-              width: "100%",
-              height: "100%",
-              borderRadius: "50%",
-              overflow: "hidden",
-              background: "#fff",
-            }}
-          >
-            <Image
-              src={photo.src}
-              alt=""
-              width={26}
-              height={26}
-              style={{
-                width: "100%",
-                height: "100%",
-                objectFit: "cover",
-                display: "block",
-              }}
-            />
-          </div>
+          <Image
+            src={photo.src}
+            alt=""
+            width={size}
+            height={Math.round(size * 0.7)}
+            style={{ width: "100%", height: "auto", display: "block" }}
+          />
         </div>
-        <span style={{ fontSize: 13, fontWeight: 600 }}>
-          {photo.user ?? "hytalemodding"}
-        </span>
       </div>
-
-      {/* image */}
-      <div
-        onClick={() => onOpen(photo.src)}
-        style={{ background: "#000", overflow: "hidden" }}
-      >
-        <Image
-          src={photo.src}
-          alt=""
-          width={size}
-          height={Math.round(size * 0.7)}
-          style={{ width: "100%", height: "auto", display: "block" }}
-        />
-      </div>
-
-      {/* actions */}
-      <div
-        style={{
-          display: "flex",
-          alignItems: "center",
-          gap: 12,
-          padding: "8px 10px 4px",
-        }}
-      >
-        <Heart size={20} style={{ fill: "#ed4956", stroke: "#ed4956" }} />
-        <MessageCircle size={20} />
-        <Send size={20} />
-        <Bookmark size={20} style={{ marginLeft: "auto" }} />
-      </div>
-
-      {/* likes + caption */}
-      <div
-        style={{
-          padding: "0 10px 10px",
-          lineHeight: 1.35,
-          flex: fill ? 1 : undefined,
-        }}
-      >
-        <p style={{ fontSize: 12, fontWeight: 600, margin: 0 }}>
-          {1200 + ((((photo.rotate * 137) % 800) + 800) % 800)} likes
-        </p>
-        <p style={{ fontSize: 12, margin: "2px 0 0" }}>
-          <span style={{ fontWeight: 600 }}>
-            {photo.user ?? "hytalemodding"}
-          </span>{" "}
-          building the future of Hytale 🛠️
-        </p>
-      </div>
-    </div>
-  );
-}
-
-function MobileDeck({
-  photos,
-  onOpen,
-}: {
-  photos: SidePhoto[];
-  onOpen: (src: string) => void;
-}) {
-  const [order, setOrder] = useState<number[]>(() => photos.map((_, i) => i));
-  const [drag, setDrag] = useState<{ x: number; y: number } | null>(null);
-  const [leaving, setLeaving] = useState<1 | -1 | null>(null);
-  const startRef = useRef<{ x: number; y: number } | null>(null);
-  const movedRef = useRef(false);
-
-  const topPos = order.length - 1;
-  const topIdx = order[topPos];
-
-  // make the deck look hand-shuffled
-  const seedX = (i: number) => ((i * 53) % 15) - 7;
-  const seedY = (i: number) => ((i * 29) % 9) - 4;
-  const seedRot = (i: number) => ((i * 37) % 9) - 4;
-
-  const onPointerDown = (e: React.PointerEvent) => {
-    e.currentTarget.setPointerCapture?.(e.pointerId);
-    startRef.current = { x: e.clientX, y: e.clientY };
-    movedRef.current = false;
-    setDrag({ x: 0, y: 0 });
-  };
-
-  const onPointerMove = (e: React.PointerEvent) => {
-    if (!startRef.current) return;
-    const dx = e.clientX - startRef.current.x;
-    const dy = e.clientY - startRef.current.y;
-    if (Math.abs(dx) > 6 || Math.abs(dy) > 6) movedRef.current = true;
-    setDrag({ x: dx, y: dy });
-  };
-
-  const endDrag = () => {
-    if (!drag) return;
-    if (Math.abs(drag.x) > 90) {
-      const dir: 1 | -1 = drag.x > 0 ? 1 : -1;
-      setLeaving(dir);
-      window.setTimeout(() => {
-        setOrder((o) => [o[o.length - 1], ...o.slice(0, o.length - 1)]);
-        setLeaving(null);
-        setDrag(null);
-        startRef.current = null;
-      }, 300);
-    } else {
-      setDrag(null);
-      startRef.current = null;
-    }
-  };
-
-  const onClickCapture = (e: React.MouseEvent) => {
-    // swallow the click that follows a drag so it doesn't open the lightbox
-    if (movedRef.current) {
-      e.stopPropagation();
-      e.preventDefault();
-    }
-  };
-
-  return (
-    <div className="mx-auto w-full">
-      <div style={{ display: "grid", touchAction: "pan-y" }}>
-        {order.map((idx, pos) => {
-          const photo = photos[idx];
-          const isTop = pos === topPos;
-          const depth = topPos - pos;
-          const baseRot = photo.rotate * 0.4 + seedRot(idx);
-
-          let transform = `translate(${seedX(idx)}px, ${
-            depth * 4 + seedY(idx)
-          }px) rotate(${baseRot}deg) scale(${1 - depth * 0.02})`;
-          let transition = "transform 0.3s ease";
-
-          if (isTop && leaving !== null) {
-            transform = `translate(${leaving * 140}%, ${
-              drag?.y ?? 0
-            }px) rotate(${baseRot + leaving * 18}deg)`;
-          } else if (isTop && drag) {
-            transform = `translate(${drag.x}px, ${drag.y}px) rotate(${
-              baseRot + drag.x * 0.04
-            }deg)`;
-            transition = "none";
-          }
-
-          return (
-            <div
-              key={idx}
-              style={{
-                gridArea: "1 / 1",
-                zIndex: pos,
-                transform,
-                transition,
-                pointerEvents: isTop ? "auto" : "none",
-                cursor: isTop ? "grab" : "default",
-                filter:
-                  depth > 0 ? `brightness(${1 - depth * 0.03})` : undefined,
-                userSelect: "none",
-              }}
-              onPointerDown={isTop ? onPointerDown : undefined}
-              onPointerMove={isTop ? onPointerMove : undefined}
-              onPointerUp={isTop ? endDrag : undefined}
-              onPointerCancel={isTop ? endDrag : undefined}
-              onClickCapture={isTop ? onClickCapture : undefined}
-            >
-              <InstagramCard photo={photo} size={480} onOpen={onOpen} fill />
-            </div>
-          );
-        })}
-      </div>
-      <p
-        className="text-foreground/50 mt-4 text-center text-xs"
-        style={{ fontFamily: "Lexend, Geist, sans-serif" }}
-      >
-        Swipe a card to shuffle the deck · tap to enlarge
-      </p>
     </div>
   );
 }
@@ -501,8 +252,6 @@ export function CommunitySection() {
         }
         .side-photos { display: block; }
         @media (max-width: 1279px) { .side-photos { display: none; } }
-        .mobile-feed { display: none; }
-        @media (max-width: 1279px) { .mobile-feed { display: block; } }
       `}</style>
 
       <div className="side-photos" aria-hidden="true">
@@ -568,11 +317,6 @@ export function CommunitySection() {
             </div>
           </div>
         </div>
-      </div>
-
-      {/* mobile feed: shown only where the side photos are hidden */}
-      <div className="mobile-feed relative z-5 mx-auto w-full max-w-md px-4 pb-16">
-        <MobileDeck photos={PHOTOS} onOpen={setZoomedSrc} />
       </div>
     </div>
   );

--- a/src/app/[lang]/(home)/community.tsx
+++ b/src/app/[lang]/(home)/community.tsx
@@ -3,6 +3,7 @@
 import { TextLink } from "@/components/text-link";
 import { DiscordButton } from "@/components/discord-button";
 import Image from "next/image";
+import { Heart, MessageCircle, Send, Bookmark } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import FeranImage from "@/../public/assets/landing/hero/feran.png";
@@ -15,6 +16,7 @@ type SidePhoto = {
   rotate: number;
   side: "left" | "right";
   size?: number;
+  user?: string;
 };
 
 const PHOTOS: SidePhoto[] = [
@@ -25,6 +27,7 @@ const PHOTOS: SidePhoto[] = [
     rotate: -8,
     side: "left",
     size: 340,
+    user: "hytalemodding",
   },
   {
     src: "/assets/landing/hero/photo6.png",
@@ -33,6 +36,7 @@ const PHOTOS: SidePhoto[] = [
     rotate: 10,
     side: "left",
     size: 340,
+    user: "modjam",
   },
   {
     src: "/assets/landing/hero/photo5.png",
@@ -41,6 +45,7 @@ const PHOTOS: SidePhoto[] = [
     rotate: -10,
     side: "left",
     size: 340,
+    user: "worldsmiths",
   },
   {
     src: "/assets/landing/hero/photo4.png",
@@ -49,6 +54,7 @@ const PHOTOS: SidePhoto[] = [
     rotate: 9,
     side: "left",
     size: 340,
+    user: "creators",
   },
   {
     src: "/assets/landing/hero/photo3.png",
@@ -57,6 +63,7 @@ const PHOTOS: SidePhoto[] = [
     rotate: 10,
     side: "right",
     size: 340,
+    user: "townhall",
   },
   {
     src: "/assets/landing/hero/photo8.png",
@@ -65,6 +72,7 @@ const PHOTOS: SidePhoto[] = [
     rotate: -10,
     side: "right",
     size: 340,
+    user: "buildclub",
   },
   {
     src: "/assets/landing/hero/photo7.png",
@@ -73,6 +81,7 @@ const PHOTOS: SidePhoto[] = [
     rotate: 8,
     side: "right",
     size: 340,
+    user: "artistry",
   },
   {
     src: "/assets/landing/hero/photo1.png",
@@ -81,6 +90,7 @@ const PHOTOS: SidePhoto[] = [
     rotate: -10,
     side: "right",
     size: 340,
+    user: "community",
   },
 ];
 
@@ -134,30 +144,269 @@ function Polaroid({
           pointerEvents: "none",
         }}
       >
+        <InstagramCard
+          photo={photo}
+          size={size}
+          onOpen={onOpen}
+          hovered={hovered}
+          rotate={photo.rotate}
+        />
+      </div>
+    </div>
+  );
+}
+
+function InstagramCard({
+  photo,
+  size,
+  onOpen,
+  hovered = false,
+  rotate = 0,
+  fill = false,
+}: {
+  photo: SidePhoto;
+  size: number;
+  onOpen: (src: string) => void;
+  hovered?: boolean;
+  rotate?: number;
+  fill?: boolean;
+}) {
+  return (
+    <div
+      style={{
+        transform: rotate ? `rotate(${rotate}deg)` : undefined,
+        background: "#fff",
+        borderRadius: 12,
+        overflow: "hidden",
+        border: "1px solid rgba(0,0,0,0.08)",
+        height: fill ? "100%" : undefined,
+        display: fill ? "flex" : undefined,
+        flexDirection: fill ? "column" : undefined,
+        boxShadow: hovered
+          ? "0 16px 30px rgba(0,0,0,0.30)"
+          : "0 5px 16px rgba(0,0,0,0.20)",
+        pointerEvents: "auto",
+        cursor: "pointer",
+        transition: "box-shadow 0.3s ease",
+        color: "#0f172a",
+      }}
+    >
+      {/* header */}
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: 8,
+          padding: "8px 10px",
+        }}
+      >
         <div
-          onClick={() => onOpen(photo.src)}
           style={{
-            transform: `rotate(${photo.rotate}deg)`,
-            border: "4px solid var(--paper, #fff)",
-            borderRadius: 10,
-            overflow: "hidden",
-            boxShadow: hovered
-              ? "0 14px 26px rgba(0,0,0,0.28)"
-              : "0 4px 14px rgba(0,0,0,0.18)",
-            pointerEvents: "auto",
-            cursor: "pointer",
-            transition: "box-shadow 0.3s ease",
+            width: 26,
+            height: 26,
+            borderRadius: "50%",
+            padding: 2,
+            background:
+              "linear-gradient(45deg,#f09433,#e6683c,#dc2743,#cc2366,#bc1888)",
+            flexShrink: 0,
           }}
         >
-          <Image
-            src={photo.src}
-            alt=""
-            width={size}
-            height={Math.round(size * 0.7)}
-            style={{ width: "100%", height: "auto", display: "block" }}
-          />
+          <div
+            style={{
+              width: "100%",
+              height: "100%",
+              borderRadius: "50%",
+              overflow: "hidden",
+              background: "#fff",
+            }}
+          >
+            <Image
+              src={photo.src}
+              alt=""
+              width={26}
+              height={26}
+              style={{
+                width: "100%",
+                height: "100%",
+                objectFit: "cover",
+                display: "block",
+              }}
+            />
+          </div>
         </div>
+        <span style={{ fontSize: 13, fontWeight: 600 }}>
+          {photo.user ?? "hytalemodding"}
+        </span>
       </div>
+
+      {/* image */}
+      <div
+        onClick={() => onOpen(photo.src)}
+        style={{ background: "#000", overflow: "hidden" }}
+      >
+        <Image
+          src={photo.src}
+          alt=""
+          width={size}
+          height={Math.round(size * 0.7)}
+          style={{ width: "100%", height: "auto", display: "block" }}
+        />
+      </div>
+
+      {/* actions */}
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: 12,
+          padding: "8px 10px 4px",
+        }}
+      >
+        <Heart size={20} style={{ fill: "#ed4956", stroke: "#ed4956" }} />
+        <MessageCircle size={20} />
+        <Send size={20} />
+        <Bookmark size={20} style={{ marginLeft: "auto" }} />
+      </div>
+
+      {/* likes + caption */}
+      <div
+        style={{
+          padding: "0 10px 10px",
+          lineHeight: 1.35,
+          flex: fill ? 1 : undefined,
+        }}
+      >
+        <p style={{ fontSize: 12, fontWeight: 600, margin: 0 }}>
+          {1200 + ((((photo.rotate * 137) % 800) + 800) % 800)} likes
+        </p>
+        <p style={{ fontSize: 12, margin: "2px 0 0" }}>
+          <span style={{ fontWeight: 600 }}>
+            {photo.user ?? "hytalemodding"}
+          </span>{" "}
+          building the future of Hytale 🛠️
+        </p>
+      </div>
+    </div>
+  );
+}
+
+function MobileDeck({
+  photos,
+  onOpen,
+}: {
+  photos: SidePhoto[];
+  onOpen: (src: string) => void;
+}) {
+  const [order, setOrder] = useState<number[]>(() => photos.map((_, i) => i));
+  const [drag, setDrag] = useState<{ x: number; y: number } | null>(null);
+  const [leaving, setLeaving] = useState<1 | -1 | null>(null);
+  const startRef = useRef<{ x: number; y: number } | null>(null);
+  const movedRef = useRef(false);
+
+  const topPos = order.length - 1;
+  const topIdx = order[topPos];
+
+  // make the deck look hand-shuffled
+  const seedX = (i: number) => ((i * 53) % 15) - 7;
+  const seedY = (i: number) => ((i * 29) % 9) - 4;
+  const seedRot = (i: number) => ((i * 37) % 9) - 4;
+
+  const onPointerDown = (e: React.PointerEvent) => {
+    e.currentTarget.setPointerCapture?.(e.pointerId);
+    startRef.current = { x: e.clientX, y: e.clientY };
+    movedRef.current = false;
+    setDrag({ x: 0, y: 0 });
+  };
+
+  const onPointerMove = (e: React.PointerEvent) => {
+    if (!startRef.current) return;
+    const dx = e.clientX - startRef.current.x;
+    const dy = e.clientY - startRef.current.y;
+    if (Math.abs(dx) > 6 || Math.abs(dy) > 6) movedRef.current = true;
+    setDrag({ x: dx, y: dy });
+  };
+
+  const endDrag = () => {
+    if (!drag) return;
+    if (Math.abs(drag.x) > 90) {
+      const dir: 1 | -1 = drag.x > 0 ? 1 : -1;
+      setLeaving(dir);
+      window.setTimeout(() => {
+        setOrder((o) => [o[o.length - 1], ...o.slice(0, o.length - 1)]);
+        setLeaving(null);
+        setDrag(null);
+        startRef.current = null;
+      }, 300);
+    } else {
+      setDrag(null);
+      startRef.current = null;
+    }
+  };
+
+  const onClickCapture = (e: React.MouseEvent) => {
+    // swallow the click that follows a drag so it doesn't open the lightbox
+    if (movedRef.current) {
+      e.stopPropagation();
+      e.preventDefault();
+    }
+  };
+
+  return (
+    <div className="mx-auto w-full">
+      <div style={{ display: "grid", touchAction: "pan-y" }}>
+        {order.map((idx, pos) => {
+          const photo = photos[idx];
+          const isTop = pos === topPos;
+          const depth = topPos - pos;
+          const baseRot = photo.rotate * 0.4 + seedRot(idx);
+
+          let transform = `translate(${seedX(idx)}px, ${
+            depth * 4 + seedY(idx)
+          }px) rotate(${baseRot}deg) scale(${1 - depth * 0.02})`;
+          let transition = "transform 0.3s ease";
+
+          if (isTop && leaving !== null) {
+            transform = `translate(${leaving * 140}%, ${
+              drag?.y ?? 0
+            }px) rotate(${baseRot + leaving * 18}deg)`;
+          } else if (isTop && drag) {
+            transform = `translate(${drag.x}px, ${drag.y}px) rotate(${
+              baseRot + drag.x * 0.04
+            }deg)`;
+            transition = "none";
+          }
+
+          return (
+            <div
+              key={idx}
+              style={{
+                gridArea: "1 / 1",
+                zIndex: pos,
+                transform,
+                transition,
+                pointerEvents: isTop ? "auto" : "none",
+                cursor: isTop ? "grab" : "default",
+                filter:
+                  depth > 0 ? `brightness(${1 - depth * 0.03})` : undefined,
+                userSelect: "none",
+              }}
+              onPointerDown={isTop ? onPointerDown : undefined}
+              onPointerMove={isTop ? onPointerMove : undefined}
+              onPointerUp={isTop ? endDrag : undefined}
+              onPointerCancel={isTop ? endDrag : undefined}
+              onClickCapture={isTop ? onClickCapture : undefined}
+            >
+              <InstagramCard photo={photo} size={480} onOpen={onOpen} fill />
+            </div>
+          );
+        })}
+      </div>
+      <p
+        className="text-foreground/50 mt-4 text-center text-xs"
+        style={{ fontFamily: "Lexend, Geist, sans-serif" }}
+      >
+        Swipe a card to shuffle the deck · tap to enlarge
+      </p>
     </div>
   );
 }
@@ -252,6 +501,8 @@ export function CommunitySection() {
         }
         .side-photos { display: block; }
         @media (max-width: 1279px) { .side-photos { display: none; } }
+        .mobile-feed { display: none; }
+        @media (max-width: 1279px) { .mobile-feed { display: block; } }
       `}</style>
 
       <div className="side-photos" aria-hidden="true">
@@ -317,6 +568,11 @@ export function CommunitySection() {
             </div>
           </div>
         </div>
+      </div>
+
+      {/* mobile feed: shown only where the side photos are hidden */}
+      <div className="mobile-feed relative z-5 mx-auto w-full max-w-md px-4 pb-16">
+        <MobileDeck photos={PHOTOS} onOpen={setZoomedSrc} />
       </div>
     </div>
   );

--- a/src/app/[lang]/(home)/community.tsx
+++ b/src/app/[lang]/(home)/community.tsx
@@ -244,7 +244,7 @@ export function CommunitySection() {
   }, []);
 
   return (
-    <div className="relative my-8 min-h-[820px] overflow-x-clip">
+    <div className="relative my-8 min-h-fit overflow-x-clip xl:min-h-205">
       <style>{`
         .side-photo:hover {
           box-shadow: 0 14px 26px rgba(0,0,0,0.28);
@@ -262,7 +262,7 @@ export function CommunitySection() {
 
       <PhotoLightbox src={zoomedSrc} onClose={() => setZoomedSrc(null)} />
 
-      <div className="relative z-[5] mx-auto flex h-full w-full max-w-3xl items-center justify-center gap-12 px-4 pt-35 not-lg:flex-col">
+      <div className="relative z-5 mx-auto flex h-full w-full max-w-3xl items-center justify-center gap-12 px-4 pt-16 not-lg:flex-col xl:pt-35">
         <div className="space-y-8 text-center">
           <h1
             className="text-3xl font-semibold"
@@ -297,22 +297,24 @@ export function CommunitySection() {
                 <span className="relative z-10">9,800+ modders on Discord</span>
                 <span
                   aria-hidden="true"
-                  className="absolute inset-0 -z-0 origin-right scale-x-0 bg-indigo-400 transition-transform duration-300 ease-out group-hover:origin-left group-hover:scale-x-100"
+                  className="absolute inset-0 z-0 origin-right scale-x-0 bg-indigo-400 transition-transform duration-300 ease-out group-hover:origin-left group-hover:scale-x-100"
                 />
               </TextLink>{" "}
               and start building.
             </div>
           </div>
-          <div className="relative flex flex-col items-center pb-40 not-lg:hidden">
+          <div className="relative flex flex-col items-center pb-16 lg:pb-40">
             <DiscordButton showMemberCount />
-            <DraggableSticker
-              src={FeranImage.src}
-              initialLeft="calc(50% - 80px)"
-              initialTop="calc(100% - 6rem)"
-              rotate={0}
-              width={160}
-              sizes="(max-width: 768px) 120px, 160px"
-            />
+            <div className="not-lg:hidden">
+              <DraggableSticker
+                src={FeranImage.src}
+                initialLeft="calc(50% - 80px)"
+                initialTop="calc(100% - 6rem)"
+                rotate={0}
+                width={160}
+                sizes="(max-width: 768px) 120px, 160px"
+              />
+            </div>
           </div>
         </div>
       </div>

--- a/src/app/[lang]/(home)/page.tsx
+++ b/src/app/[lang]/(home)/page.tsx
@@ -68,9 +68,7 @@ export default async function HomePage({
                       <span className="italic">{chunks}</span>
                     ),
                     badge: (chunks) => (
-                      <span className="text-shine font-bold">
-                        {chunks}
-                      </span>
+                      <span className="text-shine font-bold">{chunks}</span>
                     ),
                   })}
                 </div>

--- a/src/app/[lang]/(home)/page.tsx
+++ b/src/app/[lang]/(home)/page.tsx
@@ -68,7 +68,7 @@ export default async function HomePage({
                       <span className="italic">{chunks}</span>
                     ),
                     badge: (chunks) => (
-                      <span className="text-rainbow rounded-md py-0.5 font-bold text-black">
+                      <span className="text-shine font-bold">
                         {chunks}
                       </span>
                     ),

--- a/src/app/[lang]/(home)/page.tsx
+++ b/src/app/[lang]/(home)/page.tsx
@@ -33,7 +33,7 @@ export default async function HomePage({
   return (
     <div className="flex flex-1 flex-col">
       <Spotlight />
-      <div className="relative container mx-auto flex h-192 max-h-[calc(100vh-21rem)] min-h-fit flex-col items-center justify-center px-4 py-32 md:px-12">
+      <div className="relative container mx-auto flex h-192 max-h-[calc(100svh-9rem)] min-h-fit flex-col items-center justify-center px-4 py-20 md:max-h-[calc(100vh-21rem)] md:px-12 md:py-32">
         <div className="hidden md:block">
           <HeroStickers />
         </div>
@@ -59,7 +59,7 @@ export default async function HomePage({
                 </div>
               </div>*/}
               <h1
-                className="text-6xl font-semibold text-balance md:text-7xl"
+                className="text-4xl font-semibold text-balance sm:text-5xl md:text-7xl"
                 style={{ fontFamily: "Lexend, Geist, sans-serif" }}
               >
                 <div>

--- a/src/app/[lang]/(home)/programs.tsx
+++ b/src/app/[lang]/(home)/programs.tsx
@@ -45,13 +45,13 @@ export function ProgramsSection() {
           }}
         >
           <div className="flex flex-col gap-12">
-            <div className="flex h-12 items-center gap-6">
+            <div className="flex h-9 items-center gap-3 sm:h-12 sm:gap-6">
               <Image
                 src={HMLogoDark}
                 alt="HytaleModding Logo"
                 className="h-full w-fit"
               />
-              <XIcon className="size-6 shrink-0 text-white/50" />
+              <XIcon className="size-5 shrink-0 text-white/50 sm:size-6" />
               <Image
                 src={HytaleLogo}
                 alt="Hytale Logo"
@@ -88,13 +88,13 @@ export function ProgramsSection() {
             15-22 June
           </div>
           <div className="flex flex-col gap-12">
-            <div className="flex h-12 items-center gap-6">
+            <div className="flex h-9 items-center gap-3 sm:h-12 sm:gap-6">
               <Image
                 src={HMLogoDark}
                 alt="HytaleModding Logo"
                 className="h-full w-fit"
               />
-              <XIcon className="size-6 shrink-0 text-white/50" />
+              <XIcon className="size-5 shrink-0 text-white/50 sm:size-6" />
               <Image
                 src={HytaleLogo}
                 alt="Hytale Logo"
@@ -141,13 +141,13 @@ export function ProgramsSection() {
             className="-z-20 object-cover object-top"
           />
           <div className="flex h-full flex-col gap-12">
-            <div className="flex h-12 items-center gap-6">
+            <div className="flex h-9 items-center gap-3 sm:h-12 sm:gap-6">
               <Image
                 src={HMLogoDark}
                 alt="HytaleModding Logo"
                 className="h-full w-fit"
               />
-              <XIcon className="size-6 shrink-0 text-white/50" />
+              <XIcon className="size-5 shrink-0 text-white/50 sm:size-6" />
               <Image
                 src={BisectHostingDark}
                 alt="BisectHosting Logo"
@@ -197,13 +197,13 @@ export function ProgramsSection() {
             30 Jan-3 Feb
           </div>
           <div className="flex flex-col gap-12">
-            <div className="flex h-12 items-center gap-6">
+            <div className="flex h-9 items-center gap-3 sm:h-12 sm:gap-6">
               <Image
                 src={HMLogoDark}
                 alt="HytaleModding Logo"
                 className="h-full w-fit"
               />
-              <XIcon className="size-6 shrink-0 text-white/50" />
+              <XIcon className="size-5 shrink-0 text-white/50 sm:size-6" />
               <Image
                 src={NitradoLogoColored}
                 alt="Nitrado Logo"

--- a/src/app/styles/global.css
+++ b/src/app/styles/global.css
@@ -129,27 +129,38 @@
   }
 }
 
-@keyframes rainbow-flow {
-  to {
-    background-position: 200% center;
+@keyframes shine-sweep {
+  0% {
+    background-position: 100% center;
+  }
+  100% {
+    background-position: -100% center;
   }
 }
 
-.text-rainbow {
+.text-shine {
   background-image: linear-gradient(
-    90deg,
-    #ff5757,
-    #ffb347,
-    #fff34f,
-    #4ade80,
-    #38bdf8,
-    #a78bfa,
-    #f472b6,
-    #ff5757
+    110deg,
+    var(--foreground) 0%,
+    var(--foreground) 40%,
+    #c7d2fe 46%,
+    #fff 50%,
+    #bae6fd 54%,
+    var(--foreground) 60%,
+    var(--foreground) 100%
   );
-  background-size: 200% auto;
+  background-size: 250% auto;
   background-clip: text;
   -webkit-background-clip: text;
   -webkit-text-fill-color: transparent;
-  animation: rainbow-flow 8s linear infinite;
+  color: transparent;
+  padding-right: 0.06em;
+  animation: shine-sweep 6s cubic-bezier(0.45, 0, 0.55, 1) infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .text-shine {
+    animation: none;
+    background-position: 100% center;
+  }
 }

--- a/src/components/instagram-post.tsx
+++ b/src/components/instagram-post.tsx
@@ -1,0 +1,289 @@
+"use client";
+
+import Image from "next/image";
+import { Heart, MessageCircle, Send, Bookmark } from "lucide-react";
+import { useRef, useState } from "react";
+
+export type InstagramPostData = {
+  /** Image shown in the post (and, by default, in the avatar). */
+  src: string;
+  /** Account handle rendered in the header and caption. */
+  user?: string;
+  /** Optional avatar image; falls back to `src`. */
+  avatarSrc?: string;
+  /** Caption text after the username. */
+  caption?: React.ReactNode;
+  /** Like count; when omitted a stable value is derived from `rotate`. */
+  likes?: number;
+  /** Rotation used for the derived like count / deck tilt. */
+  rotate?: number;
+};
+
+function likeCount(post: InstagramPostData): number {
+  if (typeof post.likes === "number") return post.likes;
+  const r = post.rotate ?? 0;
+  return 1200 + ((((r * 137) % 800) + 800) % 800);
+}
+
+export function InstagramPost({
+  post,
+  size = 480,
+  onOpen,
+  hovered = false,
+  rotate = 0,
+  fill = false,
+}: {
+  post: InstagramPostData;
+  size?: number;
+  onOpen?: (src: string) => void;
+  hovered?: boolean;
+  rotate?: number;
+  fill?: boolean;
+}) {
+  const user = post.user ?? "hytalemodding";
+  const avatar = post.avatarSrc ?? post.src;
+
+  return (
+    <div
+      style={{
+        transform: rotate ? `rotate(${rotate}deg)` : undefined,
+        background: "#fff",
+        borderRadius: 12,
+        overflow: "hidden",
+        border: "1px solid rgba(0,0,0,0.08)",
+        height: fill ? "100%" : undefined,
+        display: fill ? "flex" : undefined,
+        flexDirection: fill ? "column" : undefined,
+        boxShadow: hovered
+          ? "0 16px 30px rgba(0,0,0,0.30)"
+          : "0 5px 16px rgba(0,0,0,0.20)",
+        pointerEvents: "auto",
+        cursor: onOpen ? "pointer" : "default",
+        transition: "box-shadow 0.3s ease",
+        color: "#0f172a",
+      }}
+    >
+      {/* header */}
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: 8,
+          padding: "8px 10px",
+        }}
+      >
+        <div
+          style={{
+            width: 26,
+            height: 26,
+            borderRadius: "50%",
+            padding: 2,
+            background:
+              "linear-gradient(45deg,#f09433,#e6683c,#dc2743,#cc2366,#bc1888)",
+            flexShrink: 0,
+          }}
+        >
+          <div
+            style={{
+              width: "100%",
+              height: "100%",
+              borderRadius: "50%",
+              overflow: "hidden",
+              background: "#fff",
+            }}
+          >
+            <Image
+              src={avatar}
+              alt=""
+              width={26}
+              height={26}
+              style={{
+                width: "100%",
+                height: "100%",
+                objectFit: "cover",
+                display: "block",
+              }}
+            />
+          </div>
+        </div>
+        <span style={{ fontSize: 13, fontWeight: 600 }}>{user}</span>
+      </div>
+
+      {/* image */}
+      <div
+        onClick={onOpen ? () => onOpen(post.src) : undefined}
+        style={{ background: "#000", overflow: "hidden" }}
+      >
+        <Image
+          src={post.src}
+          alt=""
+          width={size}
+          height={Math.round(size * 0.7)}
+          style={{ width: "100%", height: "auto", display: "block" }}
+        />
+      </div>
+
+      {/* actions */}
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: 12,
+          padding: "8px 10px 4px",
+        }}
+      >
+        <Heart size={20} style={{ fill: "#ed4956", stroke: "#ed4956" }} />
+        <MessageCircle size={20} />
+        <Send size={20} />
+        <Bookmark size={20} style={{ marginLeft: "auto" }} />
+      </div>
+
+      {/* likes + caption */}
+      <div
+        style={{
+          padding: "0 10px 10px",
+          lineHeight: 1.35,
+          flex: fill ? 1 : undefined,
+        }}
+      >
+        <p style={{ fontSize: 12, fontWeight: 600, margin: 0 }}>
+          {likeCount(post)} likes
+        </p>
+        <p style={{ fontSize: 12, margin: "2px 0 0" }}>
+          <span style={{ fontWeight: 600 }}>{user}</span>{" "}
+          {post.caption ?? "building the future of Hytale 🛠️"}
+        </p>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * A hand-shuffled deck of {@link InstagramPost} cards. Drag the top card
+ * sideways to fling it away; it reinserts at the bottom of the deck.
+ */
+export function InstagramPostDeck({
+  posts,
+  onOpen,
+  size = 480,
+  hint = "Swipe a card to shuffle the deck · tap to enlarge",
+}: {
+  posts: InstagramPostData[];
+  onOpen?: (src: string) => void;
+  size?: number;
+  hint?: string;
+}) {
+  const [order, setOrder] = useState<number[]>(() => posts.map((_, i) => i));
+  const [drag, setDrag] = useState<{ x: number; y: number } | null>(null);
+  const [leaving, setLeaving] = useState<1 | -1 | null>(null);
+  const startRef = useRef<{ x: number; y: number } | null>(null);
+  const movedRef = useRef(false);
+
+  const topPos = order.length - 1;
+
+  // make the deck look hand-shuffled
+  const seedX = (i: number) => ((i * 53) % 15) - 7;
+  const seedY = (i: number) => ((i * 29) % 9) - 4;
+  const seedRot = (i: number) => ((i * 37) % 9) - 4;
+
+  const onPointerDown = (e: React.PointerEvent) => {
+    e.currentTarget.setPointerCapture?.(e.pointerId);
+    startRef.current = { x: e.clientX, y: e.clientY };
+    movedRef.current = false;
+    setDrag({ x: 0, y: 0 });
+  };
+
+  const onPointerMove = (e: React.PointerEvent) => {
+    if (!startRef.current) return;
+    const dx = e.clientX - startRef.current.x;
+    const dy = e.clientY - startRef.current.y;
+    if (Math.abs(dx) > 6 || Math.abs(dy) > 6) movedRef.current = true;
+    setDrag({ x: dx, y: dy });
+  };
+
+  const endDrag = () => {
+    if (!drag) return;
+    if (Math.abs(drag.x) > 90) {
+      const dir: 1 | -1 = drag.x > 0 ? 1 : -1;
+      setLeaving(dir);
+      window.setTimeout(() => {
+        setOrder((o) => [o[o.length - 1], ...o.slice(0, o.length - 1)]);
+        setLeaving(null);
+        setDrag(null);
+        startRef.current = null;
+      }, 300);
+    } else {
+      setDrag(null);
+      startRef.current = null;
+    }
+  };
+
+  const onClickCapture = (e: React.MouseEvent) => {
+    // swallow the click that follows a drag so it doesn't open the lightbox
+    if (movedRef.current) {
+      e.stopPropagation();
+      e.preventDefault();
+    }
+  };
+
+  return (
+    <div className="mx-auto w-full">
+      <div style={{ display: "grid", touchAction: "pan-y" }}>
+        {order.map((idx, pos) => {
+          const post = posts[idx];
+          const isTop = pos === topPos;
+          const depth = topPos - pos;
+          const baseRot = (post.rotate ?? 0) * 0.4 + seedRot(idx);
+
+          let transform = `translate(${seedX(idx)}px, ${
+            depth * 4 + seedY(idx)
+          }px) rotate(${baseRot}deg) scale(${1 - depth * 0.02})`;
+          let transition = "transform 0.3s ease";
+
+          if (isTop && leaving !== null) {
+            transform = `translate(${leaving * 140}%, ${
+              drag?.y ?? 0
+            }px) rotate(${baseRot + leaving * 18}deg)`;
+          } else if (isTop && drag) {
+            transform = `translate(${drag.x}px, ${drag.y}px) rotate(${
+              baseRot + drag.x * 0.04
+            }deg)`;
+            transition = "none";
+          }
+
+          return (
+            <div
+              key={idx}
+              style={{
+                gridArea: "1 / 1",
+                zIndex: pos,
+                transform,
+                transition,
+                pointerEvents: isTop ? "auto" : "none",
+                cursor: isTop ? "grab" : "default",
+                filter:
+                  depth > 0 ? `brightness(${1 - depth * 0.03})` : undefined,
+                userSelect: "none",
+              }}
+              onPointerDown={isTop ? onPointerDown : undefined}
+              onPointerMove={isTop ? onPointerMove : undefined}
+              onPointerUp={isTop ? endDrag : undefined}
+              onPointerCancel={isTop ? endDrag : undefined}
+              onClickCapture={isTop ? onClickCapture : undefined}
+            >
+              <InstagramPost post={post} size={size} onOpen={onOpen} fill />
+            </div>
+          );
+        })}
+      </div>
+      {hint ? (
+        <p
+          className="text-foreground/50 mt-4 text-center text-xs"
+          style={{ fontFamily: "Lexend, Geist, sans-serif" }}
+        >
+          {hint}
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/src/components/showcase.tsx
+++ b/src/components/showcase.tsx
@@ -223,7 +223,7 @@ const showcaseItems: ShowcaseItem[] = [
     image: ColdestReaches,
     link: "https://www.curseforge.com/hytale/mods/fullmetal-labyrinth",
     type: "worldgen",
-  }
+  },
 ];
 
 const ShowcaseCard = ({ item }: { item: ShowcaseItem }) => {


### PR DESCRIPTION
# Pull Request

## Description

This PR focuses on improving the new homepage redesign's responsiveness and adds some other tweaks.

- Adjust basic responsive issues of homepage
- replace the rainbow text effect with a shine effect
- Convert the side images to posts and add shuffle deck for mobile view

## Type of Change

- [ ] Documentation fix (typo, grammar, clarification)
- [ ] New documentation (guide, tutorial, page)
- [ ] Bug fix
- [x] New feature
- [ ] Other

## Checklist

- [x] Tested locally with `bun run dev`
- [x] Formatted code to adhere Styleguide with `bun format`
- [x] Ran `bun audit` (no critical vulnerabilities)
- [x] Checked spelling and grammar
- [x] Verified all links work
- [x] Followed [Contributing Guidelines](../CONTRIBUTING.md)

---